### PR TITLE
update from ocs3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Core schema and data model for GSP.
 
-| Artifact           | Description                    |
-|--------------------|--------------------------------|
-| `gsp-core-model`   | GSP core data model.           |
-| `gsp-core-testkit` | GSP core laws and arbitraries. |
-| `gsp-core-db`      | GSP core data access objects.  |
+| Artifact            | Platform(s)         | Description                               |
+|---------------------|-------------------- |-------------------------------------------|
+| `gsp-core-model`    | JVM+JS, Scala 2.12  | GSP core data model.                      |
+| `gsp-core-testkit`  | JVM+JS, Scala 2.12  | GSP core laws and arbitraries.            |
+| `gsp-core-ocs2-api` | JVM+JS, Scala 2.12  | OCS2 PIO parsers for GSP core data model. |
 
-Most downstream libraries and applications will only require `gsp-core-model` and possibly `gsp-core-testkit`. The observing database will also require `gsp-core-db`. The model and schema are defined and released together in order to guarantee consistency between lookup tables and enumerated types (which are generated from the schema).
+In addition, this library builds and tests (but does not publish) core database bindings, epheris parsing, and OCS2 program import functionality. These modules will be moved into application projects as GSP progresses.
 
 ## Setting Up a Local Database
 

--- a/build.sbt
+++ b/build.sbt
@@ -157,6 +157,11 @@ lazy val ephemeris = project
   .settings(commonSettings)
   .settings(
     name := "gsp-core-ephemeris",
+    // by default, ignore network tests
+    // to run these:
+    //    sbt:gsp-core-ephemeris> set Test/testOptions := Nil
+    //    sbt:gsp-core-ephemeris> test
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork"),
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-async-http-client" % http4sVersion,
       "org.typelevel" %% "mouse"                    % mouseVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,6 @@ lazy val db = project
   )
   .enablePlugins(AutomateHeaderPlugin)
 
-// This is used by seqexec and also by the [unpublished] ocs2 module that's here temporarily.
 lazy val ocs2_api = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("modules/ocs2_api"))

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ import sbtcrossproject.CrossType
 lazy val doobieVersion        = "0.6.0"
 lazy val fs2Version           = "1.0.5"
 lazy val geminiLocalesVersion = "0.1.0-2019a"
-lazy val gspMathVersion       = "0.1.6"
+lazy val gspMathVersion       = "0.1.10"
 lazy val kindProjectorVersion = "0.10.3"
-lazy val monocleVersion       = "2.0.0"
+lazy val monocleVersion       = "2.0.1"
 lazy val paradiseVersion      = "2.1.1"
 
 inThisBuild(Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,10 @@ lazy val gspMathVersion       = "0.1.10"
 lazy val kindProjectorVersion = "0.10.3"
 lazy val monocleVersion       = "2.0.1"
 lazy val paradiseVersion      = "2.1.1"
+lazy val flywayVersion        = "6.0.4"
+lazy val http4sVersion        = "0.21.0-M6"
+lazy val scalaXmlVerson       = "1.2.0"
+lazy val mouseVersion         = "0.24"
 
 inThisBuild(Seq(
   homepage := Some(url("https://github.com/gemini-hlsw/gsp-core")),
@@ -111,6 +115,7 @@ lazy val db = project
   .dependsOn(testkit.jvm)
   .settings(
     name := "gsp-core-db",
+    skip in publish := true,
     libraryDependencies ++= Seq(
       "org.tpolecat" %% "doobie-postgres"  % doobieVersion,
       "org.tpolecat" %% "doobie-scalatest" % doobieVersion  % "test"
@@ -118,3 +123,47 @@ lazy val db = project
     Test / parallelExecution := false
   )
   .enablePlugins(AutomateHeaderPlugin)
+
+// This is used by seqexec and also by the [unpublished] ocs2 module that's here temporarily.
+lazy val ocs2_api = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/ocs2_api"))
+  .dependsOn(model)
+  .settings(commonSettings)
+  .settings(
+    name := "gsp-core-ocs2-api"
+  )
+
+// This module is here to ensure it stays up to date, but it's unpublished and unused for now.
+lazy val ocs2 = project
+  .in(file("modules/ocs2"))
+  .dependsOn(model.jvm, ocs2_api.jvm, db)
+  .settings(commonSettings)
+  .settings(
+    name := "gsp-core-ocs2",
+    libraryDependencies ++= Seq(
+      "org.flywaydb"            % "flyway-core"              % flywayVersion,
+      "org.http4s"             %% "http4s-dsl"               % http4sVersion,
+      "org.http4s"             %% "http4s-blaze-server"      % http4sVersion,
+      "org.http4s"             %% "http4s-async-http-client" % http4sVersion,
+      "org.http4s"             %% "http4s-scala-xml"         % http4sVersion,
+      "org.scala-lang.modules" %% "scala-xml"                % scalaXmlVerson
+    )
+  )
+
+// This module is here to ensure it stays up to date, but it's unpublished and unused for now.
+lazy val ephemeris = project
+  .in(file("modules/ephemeris"))
+  .dependsOn(model.jvm, testkit.jvm, db)
+  .settings(commonSettings)
+  .settings(
+    name := "gsp-core-ephemeris",
+    libraryDependencies ++= Seq(
+      "org.http4s"    %% "http4s-async-http-client" % http4sVersion,
+      "org.typelevel" %% "mouse"                    % mouseVersion,
+      // GspCoreDb.value,
+      // GspCoreTestkit.value,
+      // Mouse.value,
+      // Fs2IO
+    )
+  )

--- a/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/SmartGcalSpec.scala
@@ -13,7 +13,8 @@ import gem.config.GcalConfig.GcalLamp
 import gem.enum._
 import gem.util.Location
 import gsp.math.Index
-import org.scalatest.{Assertion, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import java.time.Duration
 import scala.collection.immutable.{ TreeMap, TreeSet }

--- a/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/StepDaoSpec.scala
@@ -10,7 +10,7 @@ import gem.config.F2Config.F2FpuChoice.Builtin
 import gem.enum._
 import gsp.math.{ Angle, Index, Offset }
 import java.time.Duration
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import scala.collection.immutable.{ TreeMap, TreeSet }
 

--- a/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
+++ b/modules/db/src/test/scala/gem/dao/UserDaoSpec.scala
@@ -9,6 +9,7 @@ import doobie.postgres.implicits._
 import gem._
 import gem.enum.ProgramRole
 import gsp.math.syntax.prism._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -13,6 +13,7 @@ import gem.config._
 import gem.util.{ Timestamp, Location }
 import gsp.math._
 import java.time.LocalDate
+import org.scalatest.matchers.should.Matchers
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import scala.collection.immutable.{ TreeMap, TreeSet }

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisCompression.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisCompression.scala
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.Ephemeris
+import gsp.math.{ Angle, Offset }
+import gem.syntax.stream._
+
+import cats.implicits._
+
+import fs2.Pipe
+
+import java.time.Duration
+
+
+/** FS2 pipes for discarding ephemeris elements that differ one from the other
+  * by less than a given Δ velocity or accumulated acceleration.
+  */
+trait EphemerisCompression {
+
+  import EphemerisCompression._
+
+  /** Standard velocity threshold for compression, 0.1 arcsec/hour. */
+  val StandardVelocityLimitµas: Long =
+    Angle.milliarcseconds.reverseGet(100).toMicroarcseconds
+
+  /** An `fs2.Pipe` that passes only elements which differ by more than the
+    * provided delta velocity.
+    *
+    * @param µas difference in velocity below this threshold result in
+    *            skipping elements
+    */
+  def velocityCompression[F[_]](µas: Long): Pipe[F, Ephemeris.Element, Ephemeris.Element] = {
+    def Δv(e0: Element, e1: Element): Long = {
+      val dp = e0.µasP - e1.µasP
+      val dq = e0.µasQ - e1.µasQ
+      math.hypot(dp, dq).round
+    }
+
+    _.zipWithNext
+     .filterWithPrevious { case ((prev, _), (cur, onext)) =>
+       onext.forall { _ => Δv(prev, cur) > µas }
+     }.map(_._1)
+  }
+
+  /** An `fs2.Pipe` that passes only elements which differ by more than the
+    * standard delta velocity.
+    */
+  def standardVelocityCompression[F[_]]: Pipe[F, Ephemeris.Element, Ephemeris.Element] =
+    velocityCompression(StandardVelocityLimitµas)
+
+
+  /** Standard acceleration threshold for compression, 0.2 arcsec/hour^2. */
+  val StandardAccelerationLimitµas: Long =
+    Angle.milliarcseconds.reverseGet(200).toMicroarcseconds
+
+  /** An `fs2.Pipe` that passes only elements which sufficiently differ by an
+    * accumulated average acceleration.
+    *
+    * @param µas difference in acceleration below this threshold result in
+    *            skipping elements
+    */
+  def accelerationCompression[F[_]](µas: Long): Pipe[F, Element, Element] = {
+
+    final case class SumAvgs(a: AvgAcceleration, n: Int) {
+      def +(next: AvgAcceleration): SumAvgs =
+        SumAvgs(a + next, n + 1)
+
+      def keep: Boolean =
+        (0.5 * a.acceleration / n.toDouble * a.hours * a.hours).round > µas
+    }
+
+    val Zero = Option(SumAvgs(AvgAcceleration.Zero, 0))
+
+    // The fold function.  It is complicated by the use of Option to ensure that
+    // the first and last element are always included. The `oa` parameter below
+    // is `None` for the first and last element, which means the sum including
+    // `oa` is `None`, which the filter function `_.forall(_.keep)` passes.
+    def f(os: Option[SumAvgs], oa: Option[AvgAcceleration]): Option[SumAvgs] =
+      (os, oa).tupled.map { case (sum, a) => sum + a }
+
+    _.zipWithPreviousAndNext
+     .map {
+       case (None,       cur, _   ) => (Option.empty[AvgAcceleration],            cur) // First element (should always be included)
+       case (_,          cur, None) => (Option.empty[AvgAcceleration],            cur) // Last element (should always be included)
+       case (Some(prev), cur, _   ) => (Some(AvgAcceleration.between(prev, cur)), cur)
+    }.filterOnFold(Zero)((os, oe) => f(os, oe._1), _.forall(_.keep))
+     .map(_._2) // forget the avg acceleration and just extract the element
+  }
+
+  /** An `fs2.Pipe` that passes only elements which differ by more than the
+    * standard average acceleration.
+    */
+  def standardAccelerationCompression[F[_]]: Pipe[F, Ephemeris.Element, Ephemeris.Element] =
+    accelerationCompression(StandardAccelerationLimitµas)
+}
+
+object EphemerisCompression extends EphemerisCompression {
+
+  private type Element = Ephemeris.Element
+
+  private class ElementOps(val self: Element) extends AnyVal {
+    private def µas(f: Offset => Angle): Double =
+      Angle.signedMicroarcseconds.get(f(self._2.delta)).toDouble
+
+    // Extracts the velocity in p as decimal microarcseconds / hour
+    def µasP: Double =
+      µas(_.p.toAngle)
+
+    // Extracts the velocity in q as decimal microarcseconds / hour
+    def µasQ: Double =
+      µas(_.q.toAngle)
+  }
+
+  private implicit def ToElementOps(e: Element): ElementOps = new ElementOps(e)
+
+  /** Average acceleration and the time amount over which it is averaged.
+    *
+    * @param acceleration microarcseconds / hour / hour
+    * @param hours        decimal hours
+    */
+  private final case class AvgAcceleration(acceleration: Double, hours: Double) {
+
+    def +(that: AvgAcceleration): AvgAcceleration =
+      AvgAcceleration(acceleration + that.acceleration, hours + that.hours)
+  }
+
+  private object AvgAcceleration {
+
+    val Zero = AvgAcceleration(0.0, 0.0)
+
+    /** Calculates the average acceleration from one element to the next. */
+    def between(prev: Element, cur: Element): AvgAcceleration = {
+      // time since previous
+      val d = Duration.between(prev._1.toInstant, cur._1.toInstant)
+
+      // time since previous as decimal hours
+      val h = d.toMillis.toDouble / Duration.ofHours(1).toMillis.toDouble
+
+      val dp = (cur.µasP - prev.µasP)/h
+      val dq = (cur.µasQ - prev.µasQ)/h
+
+      AvgAcceleration(math.hypot(dp, dq), h)
+    }
+  }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisContext.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisContext.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package horizons
+
+import gem.enum.Site
+import gem.util.Timestamp
+
+import cats.implicits._
+import scala.math.Ordering.Implicits._
+
+
+/** Collection of information related to an ephemeris.  Used to determine
+  * whether an update is needed.
+  *
+  * @param key  unique horizons id of the object
+  * @param site information valid for the given site
+  * @param meta associated ephemeris metadata, if any
+  * @param rnge earliest and latest ephemeris element times, if any
+  * @param soln current horizons solution reference from JPL, if any
+  */
+final case class EphemerisContext(
+  key:  EphemerisKey.Horizons,
+  site: Site,
+  meta: Option[EphemerisMeta],
+  rnge: Option[(Timestamp, Timestamp)],
+  soln: Option[HorizonsSolutionRef]
+) {
+
+  /** Determines whether the existing ephemeris, if any, covers the given
+    * semester.
+    */
+  def coversSemester(sem: Semester): Boolean =
+    rnge.exists { case (start, end) =>
+      (start.toInstant <= sem.start.atSite(site).toInstant) &&
+        (sem.end.atSite(site).toInstant <= end.toInstant)
+    }
+
+  /** Whether the database and latest horizons version data matches. */
+  val sameSolution: Boolean =
+    (meta.flatMap(_.solnRef), soln).tupled.exists { case (s0, s1) =>
+      s0 === s1
+    }
+
+  /** Determines whether updates are needed to obtain the latest ephemeris for
+    * the given semester.
+    */
+  def isUpToDateFor(sem: Semester): Boolean =
+    coversSemester(sem) && sameSolution
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/EphemerisParser.scala
@@ -1,0 +1,143 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package horizons
+
+import gem.math.{ Ephemeris, EphemerisCoordinates }
+import gem.util.Timestamp
+import gsp.math.{ Angle, Offset }
+
+import atto.ParseResult
+import atto.ParseResult.Done
+import atto.syntax.parser._
+
+import cats.ApplicativeError
+import cats.implicits._
+
+import fs2.Pipe
+
+import scala.math.BigDecimal.RoundingMode.HALF_EVEN
+
+
+/** Horizons ephemeris parser.  Parses horizons output generated with the flags
+  *
+  *   `QUANTITIES=1; time digits=FRACSEC; extra precision=YES`
+  *
+  * into an `Ephemeris` object, or a `Stream[Ephemeris.Element]`.
+  */
+object EphemerisParser {
+
+  private object impl {
+
+    import atto._
+    import Atto._
+    import cats.implicits._
+    import gsp.math.parser.CoordinateParsers._
+    import gsp.math.parser.MiscParsers._
+    import gsp.math.parser.TimeParsers._
+
+    val SOE           = "$$SOE"
+    val EOE           = "$$EOE"
+
+    val soe           = string(SOE)
+    val eoe           = string(EOE)
+    val skipPrefix    = manyUntil(anyChar, soe)  ~> verticalWhitespace
+    val skipEol       = skipMany(noneOf("\n\r")) ~> verticalWhitespace
+    val solarPresence = oneOf("*CNA ").void namedOpaque "solarPresence"
+    val lunarPresence = oneOf("mrts ").void namedOpaque "lunarPresence"
+
+    val deltaAngle    = bigDecimal.map { d =>
+      val µas = d.underlying.movePointRight(6).setScale(0, HALF_EVEN).longValue
+      Angle.fromMicroarcseconds(µas)
+    }
+
+    val utc: Parser[Timestamp] =
+      instantUTC(
+        genYMD(monthMMM, hyphen) named "yyyy-MMM-dd",
+        genLocalTime(colon)
+      ).flatMap(Timestamp.fromInstant(_).fold(err[Timestamp]("date out of range"))(ok))
+
+    val element: Parser[Ephemeris.Element] =
+      for {
+        _ <- space
+        i <- utc           <~ space
+        _ <- solarPresence
+        _ <- lunarPresence <~ spaces1
+        c <- coordinates   <~ spaces1
+        p <- deltaAngle    <~ spaces1
+        q <- deltaAngle
+      } yield (i, EphemerisCoordinates(c, Offset(Offset.P(p), Offset.Q(q))))
+
+    val elementLine: Parser[Ephemeris.Element] =
+      element <~ skipEol
+
+    val ephemeris: Parser[Ephemeris] =
+      skipPrefix ~> (
+        many(elementLine).map(Ephemeris.fromFoldable[List]) <~ eoe
+      )
+  }
+
+  import impl.{ element, ephemeris, SOE, EOE }
+
+  /** Parses an ephemeris file into an `Ephemeris` object in memory.
+    *
+    * @param s string containing the ephemeris data from horizons
+    *
+    * @return result of parsing the string into an `Ephemeris` object
+    */
+  def parse(s: String): ParseResult[Ephemeris] =
+    ephemeris.parseOnly(s)
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, ParseResult[Ephemeris.Element]]`.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, ParseResult[Ephemeris.Element]]`
+    */
+  def parsedElements[F[_]]: Pipe[F, String, ParseResult[Ephemeris.Element]] =
+    _.through(fs2.text.lines)
+     .dropWhile(_.trim =!= SOE)
+     .drop(1)
+     .takeWhile(_.trim =!= EOE)
+     .map(element.parseOnly)
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, Either[String, Ephemeris.Element]]` where left
+    * values indicate parsing errors.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, Either[String, Ephemeris.Element]]`
+    */
+  def eitherElements[F[_]]: Pipe[F, String, Either[String, Ephemeris.Element]] =
+    _.through(parsedElements)
+     .map(_.either)
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, Ephemeris.Element]`.  If there is a parse
+    * error reading the data, the element that does not parse is skipped.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, Ephemeris.Element]`
+    */
+  def validElements[F[_]]: Pipe[F, String, Ephemeris.Element] =
+    _.through(parsedElements)
+     .collect { case Done(_, e) => e }
+
+  /** An `fs2.Pipe` that converts a `Stream[F, String]` of ephemeris data from
+    * horizons into a `Stream[F, Ephemeris.Element]`.  If there is a parse
+    * error reading the data, the Stream raises an error.  See `Stream.onError`
+    * to handle this case.
+    *
+    * @tparam F effect to use
+    *
+    * @return pipe for a `Stream[F, String]` into a `Stream[F, Ephemeris.Element]`
+    */
+  def elements[F[_]: ApplicativeError[?[_], Throwable]]: Pipe[F, String, Ephemeris.Element] =
+    _.through(parsedElements)
+     .map(_.either.left.map(new RuntimeException(_)))
+     .rethrow
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsClient.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsClient.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.enum.Site
+
+import cats.ApplicativeError
+import cats.data.Reader
+import cats.effect.{ IO, ContextShift, Resource }
+import cats.implicits._
+
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.client.asynchttpclient.AsyncHttpClient
+
+import fs2.Stream
+import fs2.text.utf8Decode
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter
+import java.util.Locale.US
+
+/** A client for interacting with the JPL horizons service.
+  */
+object HorizonsClient {
+
+  private implicit val contextShift: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  /** A stream that emits a single client that will be shut down automatically. An global mutex
+    * ensures that only one such stream exists at a time.
+    */
+  val client: Resource[IO, Client[IO]] = AsyncHttpClient.resource[IO]()
+
+  /** Horizons service URL. */
+  val Url: String =
+    "https://ssd.jpl.nasa.gov/horizons_batch.cgi"
+
+  /** DateTimeFormatter that can format instants into the string expected by
+    * the horizons service: {{{yyyy-MMM-d HH:mm:ss.SSS}}}.
+    */
+  val DateFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MMM-d HH:mm:ss.SSS", US).withZone(UTC)
+
+  val SharedParams: Map[String, String] =
+    Map(
+      "batch"       -> "1",
+      "CSV_FORMAT"  -> "NO",
+      "TABLE_TYPE"  -> "OBSERVER"
+    )
+
+  type ParamReader[A] = Reader[Map[String, String], A]
+
+  /** Format coordinates and altitude as expected by horizons.*/
+  def formatCoords(s: Site): String =
+    f"'${s.longitude.toDoubleDegrees}%1.5f,${s.latitude.toSignedDoubleDegrees}%1.6f,${s.altitude.toDouble/1000.0}%1.3f'"
+
+  /** Format an instant as expected by horizons. */
+  def formatInstant(i: Instant): String =
+    s"'${DateFormat.format(i)}'"
+
+  /** URL encodes query params. */
+  val formatQuery: ParamReader[String] =
+    Reader {
+      _.toList
+       .map { case (k, v) => s"$k=${URLEncoder.encode(v, UTF_8.name)}" }
+       .intercalate("&")
+    }
+
+  /** Computes the URL string that matches the given parameters. */
+  val urlString: ParamReader[String] =
+    formatQuery.map { s => s"$Url?$s" }
+
+  /** Creates an http4s Uri representing the request and lifts it into IO,
+    * raising an error if there is a problem parsing the request.
+    */
+  val uri: ParamReader[IO[Uri]] =
+    urlString.map(Uri.fromString).map(ApplicativeError[IO, Throwable].fromEither)
+
+  /** Creates an http4s Request representing the request. */
+  val request: ParamReader[IO[Request[IO]]] =
+    uri.map { _.map(Request(Method.GET, _)) }
+
+  /** Creates a `Stream` of results from the horizons server when executed. */
+  val stream: ParamReader[Stream[IO, String]] =
+    request.map { r =>
+      for {
+        c <- Stream.resource(client)
+        a <- Stream.eval(r).flatMap(c.stream)
+        s <- a.body.through(utf8Decode)
+      } yield s
+    }
+
+  /** Retrieves all the horizons server outout into a single String. */
+  val fetch: ParamReader[IO[String]] =
+    request.map { r =>
+      client.use { c =>
+        c.expect[String](r)
+      }
+    }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisQuery.scala
@@ -1,0 +1,215 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.{EphemerisKey, Semester}
+import gem.enum.Site
+import gem.math.Ephemeris
+import gsp.math.syntax.time._
+
+import cats._
+import cats.effect.IO
+import cats.implicits._
+
+import fs2.Stream
+import mouse.boolean._
+
+import java.time.{Duration, Instant, Period}
+
+import scala.math.Ordering.Implicits._
+
+
+/** Representation of an Horizons ephemeris query.
+  */
+sealed trait HorizonsEphemerisQuery {
+
+  /** Query start time.  The first element returned should have this time.
+    */
+  def startTime: Instant
+
+  /** Query end time.  The last element returned should have this time.
+    */
+  def endTime: Instant
+
+  /** Requested element limit.
+    */
+  def elementLimit: Int
+
+  /** URL string corresponding the the horizons request.
+    */
+  def urlString: String
+
+  /** A stream of ephemeris elements from horizons.
+    */
+  def streamEphemeris: Stream[IO, Ephemeris.Element]
+
+}
+
+object HorizonsEphemerisQuery {
+
+  type HorizonsDesignation = EphemerisKey.Horizons
+
+  /** Maximum number of elements that may be received by an Horizons ephemeris
+    * request.
+    */
+  val MaxElements: Int =
+    90024
+
+  /** The minimum time between elements supported by an horizons request.
+    */
+  val MinStepLen: Duration =
+    Duration.ofMillis(500)
+
+  private val FixedParams = HorizonsClient.SharedParams ++ Map(
+    "CENTER"      -> "coord",
+    "COORD_TYPE"  -> "GEODETIC",
+    "extra_prec"  -> "YES",
+    "MAKE_EPHEM"  -> "YES",
+    "QUANTITIES"  -> "'1,3'",   // RA/Dec (1) and rate of change (3)
+    "time_digits" -> "FRACSEC"  // millisecond precision
+  )
+
+  /** Constructs an horizons ephemeris query for the given key, site, start/stop
+    * time range, and element limit. Note that a successful query will contain
+    * no more than 90024 elements regardless of the requested limit since
+    * Horizons responses are capped at 90024.  It will also include at least two
+    * elements (at the start and stop times). Finally, all elements must be
+    * separated by at least 500ms or else the query fails.
+    *
+    * @param key   Unique Horizons designation for the non-sidereal target of
+    *              interest
+    * @param site  site to which the ephemeris data applies
+    * @param start time at which ephemeris data should start (inclusive)
+    * @param end   time at which ephemeris data should end (inclusive)
+    * @param limit maximum number of elements requested
+    *
+    * @return an Horizons query ready to be executed
+    */
+  def apply(key:   HorizonsDesignation,
+            site:  Site,
+            start: Instant,
+            end:   Instant,
+            limit: Int): HorizonsEphemerisQuery =
+
+    new HorizonsEphemerisQuery {
+
+      override val startTime: Instant =
+        start
+
+      override val endTime: Instant =
+        end
+
+      override val elementLimit: Int =
+        limit
+
+      val reqParams = Map(
+        "COMMAND"    -> s"'${key.queryString}'",
+        "SITE_COORD" -> HorizonsClient.formatCoords(site),
+        "START_TIME" -> s"${HorizonsClient.formatInstant(start)}",
+        "STEP_SIZE"  -> (((limit max 2) min MaxElements) - 1).toString, // horizons wants # intervals -- the gap count not the element count
+        "STOP_TIME"  -> s"${HorizonsClient.formatInstant(end)}"
+      ) ++ FixedParams
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val streamEphemeris: Stream[IO, Ephemeris.Element] =
+        HorizonsClient.stream(reqParams).through(EphemerisParser.elements)
+    }
+
+  // Utility to round up a Duration up to the next ms.
+  private def roundUpMs(d: Duration): Duration =
+    (d.getNano % 1000000) match {
+      case 0 => d
+      case i => d.plusNanos(1000000L - i.toLong)
+    }
+
+  /** Constructs a List of queries for the given key, site, time range, and step
+    * size such that the entire range is covered by the combination of the
+    * returned queries. Horizons places a max element count limit on its results
+    * so this method provides a way to obtain all the queries necessary to cover
+    * a time range with a given step size.
+    *
+    * Note, Horizons requires a minimum step size of 500ms so 500ms will be used
+    * if a smaller value for `step` is requested and sub-millisecond fractions
+    * are rounded up to the next millisecond regardless.
+    *
+    * @param key   Unique Horizons designation for the non-sidereal target of
+    *              interest
+    * @param site  site to which the ephemeris data applies
+    * @param start start time for the first ephemeris element to be returned
+    * @param end   nominal end time (the actual last element may happen after
+    *              end if the step size doesn't evenly divide the total time)
+    * @param step  time (ms precision) between successive ephemeris elements (a
+    *              minimum of 500ms will be used if a smaller time is requested)
+    *
+    * @return List of queries that cover the entire time range
+    */
+  def paging(
+    key:   HorizonsDesignation,
+    site:  Site,
+    start: Instant,
+    end:   Instant,
+    step:  Duration
+  ): List[HorizonsEphemerisQuery] = {
+
+    // Calculates the list of queries with adjusted end time and step size.
+    def calc(end: Instant, step: Duration): List[HorizonsEphemerisQuery] = {
+      val maxPageDuration = step * (MaxElements - 1).toLong
+
+      Stream.unfold(start) { s =>               // page start time
+        (s <= end).option {
+          val e = (s + maxPageDuration) min end // page end time
+          val c = (Duration.between(s, e).toMillis / step.toMillis + 1).toInt // element count
+          // If the last query would produce just one element, which horizons
+          // doesn't seem to support, just ask for two elements instead.
+          val (eʹ, cʹ) = if (c === 1) (e + step, 2) else (e, c)
+          (HorizonsEphemerisQuery(key, site, s, eʹ, cʹ), eʹ + step)
+        }
+      }.toList
+    }
+
+    // Horizons doesn't support a step length below 500 ms and FRACSEC gives
+    // only ms precision.
+    val stepʹ = roundUpMs(step) max MinStepLen
+
+    // Adjust end to be an even number of multiples of the step interval ending
+    // exactly at or just beyond the given end instant.  That is, it must cover
+    // the entire range and be an even number of steps even if we have to go a
+    // bit over the given end time.
+    val endʹ  = {
+      val stepMs  = stepʹ.toMillis
+      val totalMs = roundUpMs(Duration.between(start, end)).toMillis
+      val rem     = totalMs % stepMs
+      start + Duration.ofMillis(totalMs + (if (rem === 0) 0 else stepMs - rem))
+    }
+
+    if (end <= start) List.empty else calc(endʹ, stepʹ)
+  }
+
+  def pagingSemester(
+        key:      HorizonsDesignation,
+        site:     Site,
+        semester: Semester,
+        step:     Duration,
+        padding:  Period): List[HorizonsEphemerisQuery] = {
+
+    val start = semester.start.atSite(site).minus(padding).toInstant
+    val end   = semester.end.atSite(site).plus(padding).toInstant
+
+    paging(key, site, start, end, step)
+  }
+
+  def pagingCurrentSemester(
+        key:      HorizonsDesignation,
+        site:     Site,
+        step:     Duration,
+        padding:  Period): IO[List[HorizonsEphemerisQuery]] =
+
+    Semester.current(site).map(pagingSemester(key, site, _, step, padding))
+
+  def streamAll(qs: List[HorizonsEphemerisQuery]): Stream[IO, Ephemeris.Element] =
+    Monoid.combineAll(qs.map(_.streamEphemeris))
+}
+

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -1,0 +1,136 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+package horizons
+
+import gem.dao.EphemerisDao
+import gem.enum.Site
+import gem.math.Ephemeris
+import gem.util.Timestamp
+import gem.horizons.EphemerisCompression._
+
+import cats._
+import cats.effect._
+import cats.implicits._
+
+import doobie._, doobie.implicits._
+
+import java.time.{ Duration, Period }
+
+import fs2.Stream
+
+
+/** Utility for inserting / updating en ephemeris. */
+final case class HorizonsEphemerisUpdater[M[_]: Monad: LiftIO](xa: Transactor[M]) {
+
+  import HorizonsEphemerisUpdater._
+
+  /** Constructs an action that when run will provide the current context
+    * information for an ephemeris.  This information can be used to determine
+    * whether an update is needed, to see when the last update was performed,
+    * and when the last update check happened.
+    */
+  def report(key:  EphemerisKey.Horizons, site: Site): M[EphemerisContext] =
+
+    (for {
+      meta <- EphemerisDao.selectMeta(key, site)
+      rnge <- EphemerisDao.selectTimes(key, site)
+      soln <- HorizonsSolutionRefQuery(key).lookup.to[ConnectionIO]
+    } yield EphemerisContext(key, site, meta, rnge, soln)).transact(xa)
+
+
+  /** Constructs an action that when run will insert a new ephemeris or update
+    * an existing one if necessary.
+    */
+  def update(key: EphemerisKey.Horizons, site: Site): M[Unit] =
+
+    for {
+      time <- Timestamp.now.to[M]
+      sem  <- Semester.current(site).to[M]
+      ctx  <- report(key, site)
+      _    <- updateIfNecessary(ctx, time, sem).transact(xa)
+    } yield ()
+
+
+  private def insertMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
+    EphemerisDao.insertMeta(key, site, m).void
+
+  private def updateMeta(key: EphemerisKey.Horizons, site: Site, m: EphemerisMeta): ConnectionIO[Unit] =
+    EphemerisDao.updateMeta(key, site, m).void
+
+  private def streamEphemeris(
+    key:      EphemerisKey.Horizons,
+    site:     Site,
+    semester: Semester
+  ): Stream[ConnectionIO, Ephemeris.Element] = {
+
+    val qs = HorizonsEphemerisQuery.pagingSemester(key, site, semester, StepSize, Padding)
+
+    qs.foldMap(_.streamEphemeris)
+      .through(standardAccelerationCompression)
+      .translate(λ[IO ~> ConnectionIO](_.to[ConnectionIO]))
+  }
+
+
+  private def updateIfNecessary(
+    ctx:  EphemerisContext,
+    time: Timestamp,
+    sem:  Semester
+  ): ConnectionIO[Unit] =
+
+    if (ctx.isUpToDateFor(sem)) recordUpdateCheck(ctx, time)
+    else doUpdate(ctx, time, sem)
+
+
+  private def recordUpdateCheck(
+    ctx:  EphemerisContext,
+    time: Timestamp
+  ): ConnectionIO[Unit] =
+
+    ctx.meta.fold(().pure[ConnectionIO]) { m =>
+      updateMeta(ctx.key, ctx.site, EphemerisMeta.lastUpdateCheck.set(time)(m))
+    }
+
+
+  private def doUpdate(
+    ctx:  EphemerisContext,
+    time: Timestamp,
+    sem:  Semester
+  ): ConnectionIO[Unit] = {
+
+    // Need to update both meta and ephemeris.  First the new
+    // metadata.
+    val mʹ   = EphemerisMeta(time, time, ctx.soln)
+
+    // The sink for writing the ephemeris to the database.  Have to pick either
+    // insert or update depending upon whether there is an existing ephemeris.
+    val sink = ctx.rnge.fold(EphemerisDao.streamInsert(ctx.key, ctx.site)) { _ =>
+      EphemerisDao.streamUpdate(ctx.key, ctx.site)
+    }
+
+    // Update the metadata and stream the ephemeris into the database.
+    for {
+      _ <- ctx.meta.fold(insertMeta(ctx.key, ctx.site, mʹ)) { _ =>
+             updateMeta(ctx.key, ctx.site, mʹ)
+           }
+      _ <- streamEphemeris(ctx.key, ctx.site, sem).through(sink).compile.drain
+    } yield ()
+  }
+
+}
+
+object HorizonsEphemerisUpdater {
+
+  /** Padding on either side of the semester to include in an ephemeris. */
+  val Padding: Period =
+    Period.ofMonths(1)
+
+  /** Maximum time between ephemeris elements, before removing points that
+    * should be interpolated.
+    */
+  val StepSize: Duration =
+    Duration.ofMinutes(1L)
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsNameQuery.scala
@@ -1,0 +1,247 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+
+import HorizonsNameQuery._
+
+import cats.data.EitherT
+import cats.effect.IO
+import cats.implicits._
+
+import scala.util.Either
+import scala.util.matching.Regex
+
+
+/** Horizons name-resolution query.
+  *
+  * {{{
+  *   import HorizonsNameQuery.Search.Comet
+  *
+  *   HorizonsNameQuery(Comet("Halley")).lookup.value.unsafeRunSync
+  * }}}
+  */
+sealed trait HorizonsNameQuery[A] {
+
+  /** URL string corresponding to the horizons request. */
+  def urlString: String
+
+  /** Returns a program that will perform the name lookup when executed,
+    * returing a List of ephemeris keys with their common name.
+    */
+  def lookup: Result[List[Resolution[A]]]
+}
+
+object HorizonsNameQuery {
+
+  /** Describes a non-sidereal target query of a specific type of object. */
+  sealed abstract class Search[A](val queryString: String) extends Product with Serializable
+
+  object Search {
+    final case class Comet(partial: String)     extends Search[EphemerisKey.Comet    ](s"NAME=$partial*;CAP")
+    final case class Asteroid(partial: String)  extends Search[EphemerisKey.Asteroid ](s"ASTNAM=$partial*"  )
+    final case class MajorBody(partial: String) extends Search[EphemerisKey.MajorBody](s"$partial"          )
+  }
+
+  sealed trait Error extends Product with Serializable
+
+  final case class HorizonsException(e: Throwable)                  extends Error
+  final case class ParseError(input: List[String], message: String) extends Error
+
+  /** Result of performing an horizons name resolution. */
+  type Result[A] = EitherT[IO, Error, A]
+
+  /** A human-readable name and its unique horizons ephemeris key. */
+  final case class Resolution[A](a: A, name: String)
+
+  /** Creates a NameQuery for the given search object. */
+  def apply[A](search: Search[A]): HorizonsNameQuery[A] =
+    new HorizonsNameQuery[A] {
+      import NameQueryImpl._
+
+      val reqParams = HorizonsClient.SharedParams ++ Map(
+        "MAKE_EPHEM" -> "NO",
+        "COMMAND"    -> s"'${search.queryString}'"
+      )
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val lookup: Result[List[Resolution[A]]] =
+        EitherT(HorizonsClient.fetch(reqParams).map { s =>
+          val lines = s.split('\n').toList
+          parseResponse(search, lines).leftMap(ParseError(lines, _))
+        })
+    }
+
+  private object NameQueryImpl {
+
+    // Representation of column offsets as (start, end) pairs, as deduced
+    // from --- -------- --- -----
+    type Offsets = List[(Int, Int)]
+
+    // Parse many results based on an expected header pattern. This will read
+    // through the tail until --- separators are found, then parse the
+    // remaining lines (until a blank line is encountered) using the function
+    // constructed by `f`, if any (otherwise it is assumed that there were not
+    // enough columns found). Returns a list of values or an error message.
+    def parseMany[A](header: String, tail: List[String], headerPattern: Regex)(f: Offsets => Option[String => A]): Either[String, List[A]] =
+      headerPattern.findFirstMatchIn(header).toRight("Header pattern not found: " + headerPattern.regex) *>
+        (tail.dropWhile(s => !s.trim.startsWith("---")) match {
+          case Nil                => Nil.asRight // no column headers means no results!
+          case colHeaders :: rows =>             // we have a header row with data rows following
+            val offsets = "-+".r.findAllMatchIn(colHeaders).map(m => (m.start, m.end)).toList
+            try {
+              f(offsets).map(g => rows.takeWhile(_.trim.nonEmpty).map(g)).toRight("Not enough columns.")
+            } catch {
+              case    nfe: NumberFormatException           =>  ("Number format exception: " + nfe.getMessage).asLeft
+              case      _: StringIndexOutOfBoundsException =>   "Column value(s) not found.".asLeft
+            }
+        })
+
+
+    def parseHeader[A](lines: List[String])(f: (String, List[String]) => Either[String, List[A]]): Either[String, List[A]] =
+      lines match {
+        case _ :: h :: t => f(h, t)
+        case _           => "Fewer than 2 lines!".asLeft
+      }
+
+    def parseResponse[A](s: Search[A], lines: List[String]): Either[String, List[Resolution[A]]] =
+      parseHeader[Resolution[A]](lines) { case (header, tail) =>
+        s match {
+          case Search.Comet(_)     => parseComets(header, tail)
+          case Search.Asteroid(_)  => parseAsteroids(header, tail)
+          case Search.MajorBody(_) => parseMajorBodies(header, tail)
+        }
+      }
+
+    type ParsedResolutions[A] = Either[String, List[Resolution[A]]]
+    type ParsedComets         = ParsedResolutions[EphemerisKey.Comet]
+    type ParsedAsteroids      = ParsedResolutions[EphemerisKey.Asteroid]
+    type ParsedMajorBodies    = ParsedResolutions[EphemerisKey.MajorBody]
+
+    def parseComets(header: String, tail: List[String]): ParsedComets = {
+
+      // Common case is that we have many results, or none.
+      def case0: ParsedComets =
+        parseMany[Resolution[EphemerisKey.Comet]](header, tail, """  +Small-body Index Search Results  """.r) { offs =>
+          (offs.lift(2), offs.lift(3)).mapN {
+            case ((ods, ode), (ons, _)) => { row =>
+              val desig = row.substring(ods, ode).trim
+              val name  = row.substring(ons     ).trim // last column, so no end index because rows are ragged
+              Resolution(EphemerisKey.Comet(desig), name)
+            }
+          }
+        }
+
+      // Single result with form: JPL/HORIZONS      Hubble (C/1937 P1)     2015-Dec-31 11:40:21
+      def case1: ParsedComets =
+        """  +([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.Comet(m.group(2)), m.group(1)))
+        }.toRight("Could not match 'Hubble (C/1937 P1)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS         1P/Halley           2015-Dec-31 11:40:21
+      def case2: ParsedComets =
+        """  +([^/]+)/(.+?)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.Comet(m.group(1)), m.group(2)))
+        }.toRight("Could not match '1P/Halley' header pattern.")
+
+      // First one that works!
+      case0 orElse
+      case1 orElse
+      case2 orElse "Could not parse the header line as a comet".asLeft
+    }
+
+    def parseAsteroids(header: String, tail: List[String]): ParsedAsteroids = {
+
+      // Common case is that we have many results, or none.
+      def case0: ParsedAsteroids =
+        parseMany[Resolution[EphemerisKey.Asteroid]](header, tail, """  +Small-body Index Search Results  """.r) { offs =>
+          (offs.lift(0), offs.lift(1), offs.lift(2)).mapN {
+            case ((ors, ore), (ods, ode), (ons, _)) => { row =>
+              val rec   = row.substring(ors, ore).trim.toInt
+              val desig = row.substring(ods, ode).trim
+              val name  = row.substring(ons     ).trim // last column, so no end index because rows are ragged
+              desig match {
+                case "(undefined)" => Resolution(EphemerisKey.AsteroidOld(rec): EphemerisKey.Asteroid, name)
+                case des           => Resolution(EphemerisKey.AsteroidNew(des): EphemerisKey.Asteroid, name)
+              }
+            }
+          }
+        }
+
+      // Single result with form: JPL/HORIZONS      90377 Sedna (2003 VB12)     2015-Dec-31 11:40:21
+      def case1: ParsedAsteroids =
+        """  +\d+ ([^(]+)\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(2)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '90377 Sedna (2003 VB12)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS      4 Vesta     2015-Dec-31 11:40:21
+      def case2: ParsedAsteroids =
+        """  +(\d+) ([^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidOld(m.group(1).toInt) : EphemerisKey.Asteroid, m.group(2)))
+        }.toRight("Could not match '4 Vesta' header pattern.")
+
+      // Single result with form: JPL/HORIZONS    (2016 GB222)    2016-Apr-20 15:22:36
+      def case3: ParsedAsteroids =
+        """  +\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '(2016 GB222)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS        418993 (2009 MS9)            2016-Sep-07 18:23:54
+      def case4: ParsedAsteroids =
+        """  +\d+\s+\((.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '418993 (2009 MS9)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS              1I/'Oumuamua (A/2017 U1)         2018-Apr-16 18:28:59
+      def case5: ParsedAsteroids =
+        """  +\S+\s+\((A/.+?)\)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match '1I/'Oumuamua (A/2017 U1)' header pattern.")
+
+      // Single result with form: JPL/HORIZONS     A/2017 U7     2015-Dec-31 11:40:21
+      def case6: ParsedAsteroids =
+        """  +(A/\d+ [^(]+?)  """.r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.AsteroidNew(m.group(1)) : EphemerisKey.Asteroid, m.group(1)))
+        }.toRight("Could not match 'A/2017 U7' header pattern.")
+
+      // First one that works!
+      case0 orElse
+      case1 orElse
+      case2 orElse
+      case3 orElse
+      case4 orElse
+      case5 orElse
+      case6 orElse "Could not parse the header line as an asteroid".asLeft
+    }
+
+    def parseMajorBodies(header: String, tail: List[String]): ParsedMajorBodies = {
+
+      // Common case is that we have many results, or none.
+      def case0: ParsedMajorBodies =
+        parseMany[Resolution[EphemerisKey.MajorBody]](header, tail, """Multiple major-bodies match string""".r) { offs =>
+          (offs.lift(0), offs.lift(1)).mapN {
+            case ((ors, ore), (ons, one)) => { row =>
+              val rec  = row.substring(ors, ore).trim.toInt
+              val name = row.substring(ons, one).trim
+              Resolution(EphemerisKey.MajorBody(rec.toInt), name)
+            }
+          }
+        }.map(_.filterNot(_.a.num < 0)) // filter out spacecraft
+
+      // Single result with form:  Revised: Aug 11, 2015       Charon / (Pluto)     901
+      def case1: ParsedMajorBodies =
+        """  +(.*?) / \((.+?)\)  +(\d+) *$""".r.findFirstMatchIn(header).map { m =>
+          List(Resolution(EphemerisKey.MajorBody(m.group(3).toInt), m.group(1)))
+        }.toRight("Could not match 'Charon / (Pluto)     901' header pattern.")
+
+      // First one that works, otherwise Nil because it falls through to small-body search
+      case0 orElse
+      case1 orElse Nil.asRight
+    }
+  }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsSolutionRefQuery.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsSolutionRefQuery.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import atto.Atto._
+import atto._
+import cats.effect.IO
+import gem.{EphemerisKey, HorizonsSolutionRef}
+
+/** Horizons solution reference query.  Horizons supports a version number, of
+  * sorts, for comet and asteriod ephemeris calculations.  The version is an
+  * opaque `String` that can be used to compare for equality against previous
+  * versions to determine if an update is required.  Unfortunately, major bodies
+  * do not include solution references.
+  *
+  * {{{
+  *   import gem.EphemerisKey
+  *   import gem.horizons.HorizonsSolutionRefQuery
+  *
+  *   HorizonsSolutionRefQuery(EphemerisKey.Comet("81P")).lookup.unsafeRunSync
+  * }}}
+  *
+  */
+sealed trait HorizonsSolutionRefQuery {
+
+  /** URL string corresponding to the horizons request. */
+  def urlString: String
+
+  /** Returns a program that will perform the solution reference lookup when
+    * executed.
+    */
+  def lookup: IO[Option[HorizonsSolutionRef]]
+
+}
+
+object HorizonsSolutionRefQuery {
+
+  private val FixedParams = HorizonsClient.SharedParams ++ Map(
+    "MAKE_EPHEM" -> "NO"  // We don't need actual ephemeris elements
+  )
+
+  // Comets and Asteroids have solution references.
+  private val SolnRefKey = "soln ref.="
+
+  private val solnRefParser: Parser[String] =
+    (manyUntil(anyChar, string(SolnRefKey)) ~> stringOf1(noneOf(",\n")))
+
+  // MajorBody objects don't have a solution reference proper, so we use the
+  // revision date.
+  private val RevisedKey = "Revised: "
+
+  private val revisionParser: Parser[String] =
+    (manyUntil(anyChar, string(RevisedKey)) ~> manyUntil(anyChar, string("  ")).map(_.mkString))
+
+  /** Parses the given string for a solution reference. For comets and asteroids,
+    * this will be an actual solution reference.  For major bodies it is a
+    * revision date.  Either way we treat this as opaque data only of interest
+    * for determining whether there is new data.
+    *
+    * @param k key used to determine the type of non-sidereal object
+    * @param s header for a non-sidereal object of this type
+    *
+    * @return a solution reference, if found in the header
+    */
+  def parseSolutionRef(k: EphemerisKey.Horizons, s: String): Option[HorizonsSolutionRef] = {
+    val parser = k match {
+      case EphemerisKey.MajorBody(_) => revisionParser
+      case _                         => solnRefParser
+    }
+
+    (parser.map(s => HorizonsSolutionRef(s.trim)) parseOnly s).option
+  }
+
+  /** Creates a query instance for the given ephemeris key.
+    */
+  def apply(key: EphemerisKey.Horizons): HorizonsSolutionRefQuery =
+
+    new HorizonsSolutionRefQuery {
+      val reqParams = Map(
+        "COMMAND" -> s"'${key.queryString}'"
+      ) ++ FixedParams
+
+      override val urlString: String =
+        HorizonsClient.urlString(reqParams)
+
+      override val lookup: IO[Option[HorizonsSolutionRef]] =
+        HorizonsClient
+          .fetch(reqParams)
+          .map(parseSolutionRef(key, _))
+    }
+
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsEphemerisExport.scala
@@ -1,0 +1,94 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons.tcs
+
+import gem.EphemerisKey
+import gem.dao.EphemerisDao
+import gem.enum.Site
+import gem.util.Timestamp
+
+import cats.effect._
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+
+import fs2.Stream
+import fs2.text
+import fs2.io.file
+
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption.{ CREATE, TRUNCATE_EXISTING }
+
+/** Provides support for exporting ephemeris data to files that may be read by
+  * the TCS.
+  *
+  * @param xa transactor to use for working with the database
+  */
+final class TcsEphemerisExport[M[_]: Sync: ContextShift](xa: Transactor[M]) {
+  import TcsEphemerisExport.RowLimit
+
+  /** Produces the name of the corresponding .eph file. */
+  def fileName(k: EphemerisKey): String =
+    s"${EphemerisKey.fromString.reverseGet(k)}.eph"
+
+  /** Resolves the ephemeris file corresponding to the given key. */
+  def resolve(key: EphemerisKey, dir: Path): Path =
+    dir.resolve(fileName(key))
+
+  /** Exports up to `RowLimit` lines of ephemeris data associated with the given
+    * key, site, and time range.
+    *
+    * Unless the start or end exactly matches an ephemeris element, then an
+    * entry before start, and/or after end will also be included. This ensures
+    * that the time range is fully covered and a position at any point in the
+    * range can be inferred from the ephemeris.
+    *
+    * @param path  directory to which the ephemeris data should be written
+    * @param key   key corresponding to the object to export
+    * @param site  site for which the data is relevant
+    * @param start start time for ephemeris data; if there is an element at
+    *              exactly this time it will be the first element (otherwise,
+    *              the element immediately preceeding this time is included)
+    * @param end   end time for ephemeris data; if there is an element at
+    *              exactly this time it will be the last element (otherwise,
+    *              the element immediately following this time is included)
+    */
+  def exportOne(key: EphemerisKey, site: Site, start: Timestamp, end: Timestamp, dir: Path)(blocker: Blocker): M[Unit] = {
+    import EphemerisDao.{ bracketRange, streamRange }
+
+    Stream.eval(bracketRange(key, site, start, end))
+      .flatMap { case (s, e) => streamRange(key, site, s, e) }
+      .transact(xa)
+      .take(RowLimit.toLong)
+      .through(TcsFormat.ephemeris)
+      .intersperse("\n")
+      .append(Stream.emit("\n"))
+      .through(text.utf8Encode)
+      .through(file.writeAll(resolve(key, dir), blocker, List(CREATE, TRUNCATE_EXISTING)))
+      .compile
+      .drain
+  }
+
+  /** Exports all ephemerides for the given site for the given time period. File
+    * names are invented based upon the corresponding ephemeris key.  See
+    * `EphemerisKey.format`.
+    *
+    * @param dir   directory where the ephemerides will be written
+    * @param site  site to which the ephemerides correspond
+    * @param start start time for the ephemeris data, inclusive
+    * @param end   end time for the ephemeirs day, exclusive
+    */
+  def exportAll(site: Site, start: Timestamp, end: Timestamp, dir: Path)(blocker: Blocker): M[Unit] =
+    for {
+      ks <- EphemerisDao.selectKeys(site).transact(xa)
+      _  <- ks.toList.traverse_(k => exportOne(k, site, start, end, resolve(k, dir))(blocker))
+    } yield ()
+}
+
+object TcsEphemerisExport {
+
+  /** Max ephemeris elements supported by the TCS. */
+  val RowLimit: Int =
+    1440
+}

--- a/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsFormat.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/tcs/TcsFormat.scala
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons.tcs
+
+import gem.math.Ephemeris
+import gsp.math.{ Angle, Declination, HourAngle, JulianDate, RightAscension }
+
+import cats._
+
+import fs2._
+
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter
+import java.util.Locale.US
+
+/** Formatting for TCS ephemeris files.  The TCS is very particular and
+  * unforgiving about the format, down to the column in which items start and
+  * the number of digits to the right of decimal places.
+  */
+object TcsFormat {
+
+  /** Exact header required by the TCS. */
+  val Header: String =
+    """***************************************************************************************
+      | Date__(UT)__HR:MN Date_________JDUT     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+      |***************************************************************************************""".stripMargin
+
+  /** Marker for the start of ephemeris elements in the file. */
+  val Soe: String =
+    "$$SOE"
+
+  /** Marker for the end of ephemeris elements in the file. */
+  val Eoe: String =
+    "$$EOE"
+
+  /** Date format required by the TCS. */
+  val DateFormatPattern: String      =
+    "yyyy-MMM-dd HH:mm"
+
+  val DateFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern(DateFormatPattern, US).withZone(UTC)
+
+  /** RA format, which requires 10th of a millisecond (and no more, and no less)
+    * precision.
+    */
+  def formatRa(ra: RightAscension): String = {
+    // Round to an even number of tenths of microseconds.
+    val µs         = ra.toHourAngle.toMicroseconds
+    val tenthsOfMs = (µs / 100) + ((µs % 100) + 50) / 100
+    val hms        = (HourAngle.microseconds.reverse composeIso HourAngle.hms).get(tenthsOfMs * 100)
+
+    f"${hms.hours}%02d ${hms.minutes}%02d ${hms.seconds}%02d.${hms.milliseconds}%03d${hms.microseconds/100}%01d"
+  }
+
+  /** Dec format, which requires millisecond (and no more, and no less)
+    * precision.  If positive, must have a leading space.
+    */
+  def formatDec(dec: Declination): String = {
+    val a    = dec.toAngle
+    val sµas = Angle.signedMicroarcseconds.get(a)
+
+    // Round to an even number of milliseconds
+    val µas  = (if (sµas < 0) -a else a).toMicroarcseconds
+    val mas  = (µas / 1000) + ((µas % 1000) + 500) / 1000
+    val dms  = (Angle.milliarcseconds.reverse composeIso Angle.dms).get(mas.toInt)
+
+    // -9 should format as "-09", 9 as " 09"
+    val sign = if (sµas < 0) "-" else " "
+    f"$sign${dms.degrees.abs}%02d ${dms.arcminutes}%02d ${dms.arcseconds}%02d.${dms.milliarcseconds}%03d"
+  }
+
+  def formatDeltaArcseconds(a: Angle): String =
+    f"${Angle.signedMicroarcseconds.get(a).toDouble / 1000000.0}%9.5f"
+
+  def formatElement(e: Ephemeris.Element): String = {
+    val (time, ephCoords) = e
+
+    // Time, Julian Date
+    val instant   = time.toInstant
+    val timeS     = DateFormat.format(instant)
+    val jdS       = f"${JulianDate.ofInstant(instant).toDouble}%.9f"
+
+    // Coordinates
+    val coords = ephCoords.coord
+    val coordS = s"${formatRa(coords.ra)} ${formatDec(coords.dec)}"
+    val Δ      = ephCoords.delta
+    val ΔraS   = formatDeltaArcseconds(Δ.p.toAngle)
+    val ΔdecS  = formatDeltaArcseconds(Δ.q.toAngle)
+
+    s" $timeS $jdS     $coordS $ΔraS $ΔdecS"
+  }
+
+  def elements[M[_]: Monad]: Pipe[M, Ephemeris.Element, String] =
+    _.map(formatElement)
+
+  def ephemeris[M[_]: Monad]: Pipe[M, Ephemeris.Element, String] =
+    s => Stream(Header, Soe) ++ s.map(formatElement) ++ Stream(Eoe)
+}

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly-compressed.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly-compressed.eph
@@ -1,0 +1,165 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Oct-03 07:55:49
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061
+
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+
+COMET comments
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+
+
+*******************************************************************************
+Ephemeris / WWW_USER Tue Oct  3 07:55:49 2017 Pasadena, USA      / Horizons
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-15 00:00:00.0000 UT
+Stop  time      : A.D. 2017-Aug-15 23:59:00.0000 UT
+Step-size       : 50 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL
+RTS-only print  : NO
+EOP file        : eop.171002.p171224
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-OCT-02. PREDICTS-> 2017-DEC-23
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+****************************************************************************
+$$SOE
+ 2017-Aug-15 00:00:00.000     14 50 13.1823 -02 58 45.704 9.304921  -12.4881
+ 2017-Aug-15 01:26:20.400     14 50 14.0798 -02 59 03.686 9.417733  -12.4845
+ 2017-Aug-15 02:52:40.800     14 50 14.9897 -02 59 21.664 9.562654  -12.4830
+ 2017-Aug-15 03:50:14.400     14 50 15.6045 -02 59 33.649 9.668666  -12.4834
+ 2017-Aug-15 04:47:48.000     14 50 16.2262 -02 59 45.635 9.775534  -12.4851
+ 2017-Aug-15 05:45:21.600  m  14 50 16.8545 -02 59 57.624 9.877449  -12.4880
+ 2017-Aug-15 07:11:42.000  m  14 50 17.8085 -03 00 15.613 10.00918  -12.4944
+ 2017-Aug-15 09:06:49.200  m  14 50 19.0967 -03 00 39.616 10.12254  -12.5057
+ 2017-Aug-15 13:54:37.200 *m  14 50 22.3312 -03 01 39.724 10.02491  -12.5335
+ 2017-Aug-15 15:20:57.600 *m  14 50 23.2877 -03 01 57.778 9.917012  -12.5380
+ 2017-Aug-15 16:47:18.000 *   14 50 24.2333 -03 02 15.837 9.800988  -12.5397
+ 2017-Aug-15 18:13:38.400 *   14 50 25.1682 -03 02 33.896 9.696287  -12.5386
+ 2017-Aug-15 20:37:32.400 *   14 50 26.7084 -03 03 03.985 9.593623  -12.5320
+ 2017-Aug-15 23:59:00.000     14 50 28.8594 -03 03 46.075 9.675139  -12.5193
+$$EOE
+*******************************************************************************
+Column meaning:
+
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE WITH TARGET RISE/TRANSIT/SET MARKER (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by another marker symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+        'r'  Rise    (target body on or above cut-off RTS elevation)
+        't'  Transit (target body at or past local maximum RTS elevation)
+        's'  Set     (target body on or below cut-off RTS elevation)
+
+RTS MARKERS (TVH)
+  Rise and set are with respect to the reference ellipsoid true visual horizon
+defined by the elevation cut-off angle. Horizon dip and yellow-light refraction
+(Earth only) are considered. Accuracy is < or = to twice the requested search
+step-size.
+
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+ dRA*cosD d(DEC)/dt =
+    The rate of change of target center apparent RA and DEC (airless).
+d(RA)/dt is multiplied by the cosine of the declination.
+    Units: ARCSECONDS PER HOUR
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly-error.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly-error.eph
@@ -1,0 +1,202 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Oct-03 07:55:49
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061
+
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+
+COMET comments
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+
+
+*******************************************************************************
+Ephemeris / WWW_USER Tue Oct  3 07:55:49 2017 Pasadena, USA      / Horizons
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-15 00:00:00.0000 UT
+Stop  time      : A.D. 2017-Aug-15 23:59:00.0000 UT
+Step-size       : 50 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL
+RTS-only print  : NO
+EOP file        : eop.171002.p171224
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-OCT-02. PREDICTS-> 2017-DEC-23
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+****************************************************************************
+$$SOE
+ 2017-Aug-15 00:00:00.000     14 50 13.1823 -02 58 45.704 9.304921  -12.4881
+ 2017-Aug-15 00:28:46.800     14 50 13.4803 -02 58 51.699 9.338051  -12.4867
+ 2017-Aug-15 00:57:33.600 :)  14 50 13.7794 -02 58 57.693 9.375816  -12.4855
+ 2017-Aug-15 01:26:20.400     14 50 14.0798 -02 59 03.686 9.417733  -12.4845
+ 2017-Aug-15 01:55:07.200     14 50 14.3816 -02 59 09.679 9.463256  -12.4837
+ 2017-Aug-15 02:23:54.000     14 50 14.6849 -02 59 15.671 9.511780  -12.4832
+ 2017-Aug-15 02:52:40.800     14 50 14.9897 -02 59 21.664 9.562654  -12.4830
+ 2017-Aug-15 03:21:27.600     14 50 15.2963 -02 59 27.656 9.615187  -12.4830
+ 2017-Aug-15 03:50:14.400     14 50 15.6045 -02 59 33.649 9.668666  -12.4834
+ 2017-Aug-15 04:19:01.200  s  14 50 15.9145 -02 59 39.642 9.722359  -12.4841
+ 2017-Aug-15 04:47:48.000     14 50 16.2262 -02 59 45.635 9.775534  -12.4851
+ 2017-Aug-15 05:16:34.800  m  14 50 16.5395 -02 59 51.629 9.827466  -12.4864
+ 2017-Aug-15 05:45:21.600  m  14 50 16.8545 -02 59 57.624 9.877449  -12.4880
+ 2017-Aug-15 06:14:08.400  m  14 50 17.1711 -03 00 03.619 9.924809  -12.4899
+ 2017-Aug-15 06:42:55.200  m  14 50 17.4891 -03 00 09.616 9.968913  -12.4920
+ 2017-Aug-15 07:11:42.000  m  14 50 17.8085 -03 00 15.613 10.00918  -12.4944
+ 2017-Aug-15 07:40:28.800  m  14 50 18.1291 -03 00 21.612 10.04509  -12.4970
+ 2017-Aug-15 08:09:15.600  m  14 50 18.4507 -03 00 27.612 10.07619  -12.4997
+ 2017-Aug-15 08:38:02.400  m  14 50 18.7733 -03 00 33.613 10.10210  -12.5026
+ 2017-Aug-15 09:06:49.200  m  14 50 19.0967 -03 00 39.616 10.12254  -12.5057
+ 2017-Aug-15 09:35:36.000  m  14 50 19.4205 -03 00 45.621 10.13730  -12.5087
+ 2017-Aug-15 10:04:22.800 Am  14 50 19.7448 -03 00 51.627 10.14625  -12.5119
+ 2017-Aug-15 10:33:09.600 Nm  14 50 20.0693 -03 00 57.634 10.14938  -12.5150
+ 2017-Aug-15 11:01:56.400 Cm  14 50 20.3938 -03 01 03.643 10.14676  -12.5181
+ 2017-Aug-15 11:30:43.200 *m  14 50 20.7181 -03 01 09.653 10.13853  -12.5210
+ 2017-Aug-15 11:59:30.000 *m  14 50 21.0420 -03 01 15.665 10.12495  -12.5239
+ 2017-Aug-15 12:28:16.800 *m  14 50 21.3654 -03 01 21.678 10.10635  -12.5266
+ 2017-Aug-15 12:57:03.600 *m  14 50 21.6882 -03 01 27.692 10.08314  -12.5291
+ 2017-Aug-15 13:25:50.400 *m  14 50 22.0102 -03 01 33.708 10.05581  -12.5314
+ 2017-Aug-15 13:54:37.200 *m  14 50 22.3312 -03 01 39.724 10.02491  -12.5335
+ 2017-Aug-15 14:23:24.000 *m  14 50 22.6512 -03 01 45.741 9.991028  -12.5353
+ 2017-Aug-15 14:52:10.800 *m  14 50 22.9700 -03 01 51.760 9.954834  -12.5368
+ 2017-Aug-15 15:20:57.600 *m  14 50 23.2877 -03 01 57.778 9.917012  -12.5380
+ 2017-Aug-15 15:49:44.400 *r  14 50 23.6041 -03 02 03.798 9.878277  -12.5389
+ 2017-Aug-15 16:18:31.200 *m  14 50 23.9193 -03 02 09.817 9.839359  -12.5394
+ 2017-Aug-15 16:47:18.000 *   14 50 24.2333 -03 02 15.837 9.800988  -12.5397
+ 2017-Aug-15 17:16:04.800 *   14 50 24.5461 -03 02 21.857 9.763889  -12.5396
+ 2017-Aug-15 17:44:51.600 *   14 50 24.8576 -03 02 27.876 9.728765  -12.5393
+ 2017-Aug-15 18:13:38.400 *   14 50 25.1682 -03 02 33.896 9.696287  -12.5386
+ 2017-Aug-15 18:42:25.200 *   14 50 25.4777 -03 02 39.915 9.667085  -12.5377
+ 2017-Aug-15 19:11:12.000 *   14 50 25.7863 -03 02 45.933 9.641736  -12.5366
+ 2017-Aug-15 19:39:58.800 *   14 50 26.0942 -03 02 51.951 9.620757  -12.5352
+ 2017-Aug-15 20:08:45.600 *   14 50 26.4015 -03 02 57.968 9.604596  -12.5337
+ 2017-Aug-15 20:37:32.400 *   14 50 26.7084 -03 03 03.985 9.593623  -12.5320
+ 2017-Aug-15 21:06:19.200 *   14 50 27.0150 -03 03 10.000 9.588128  -12.5302
+ 2017-Aug-15 21:35:06.000 *   14 50 27.3216 -03 03 16.015 9.588312  -12.5284
+ 2017-Aug-15 22:03:52.800 *t  14 50 27.6282 -03 03 22.029 9.594287  -12.5265
+ 2017-Aug-15 22:32:39.600 C   14 50 27.9351 -03 03 28.042 9.606074  -12.5246
+ 2017-Aug-15 23:01:26.400 N   14 50 28.2425 -03 03 34.054 9.623602  -12.5227
+ 2017-Aug-15 23:30:13.200 A   14 50 28.5505 -03 03 40.065 9.646707  -12.5210
+ 2017-Aug-15 23:59:00.000     14 50 28.8594 -03 03 46.075 9.675139  -12.5193
+$$EOE
+*******************************************************************************
+Column meaning:
+
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE WITH TARGET RISE/TRANSIT/SET MARKER (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by another marker symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+        'r'  Rise    (target body on or above cut-off RTS elevation)
+        't'  Transit (target body at or past local maximum RTS elevation)
+        's'  Set     (target body on or below cut-off RTS elevation)
+
+RTS MARKERS (TVH)
+  Rise and set are with respect to the reference ellipsoid true visual horizon
+defined by the elevation cut-off angle. Horizon dip and yellow-light refraction
+(Earth only) are considered. Accuracy is < or = to twice the requested search
+step-size.
+
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+ dRA*cosD d(DEC)/dt =
+    The rate of change of target center apparent RA and DEC (airless).
+d(RA)/dt is multiplied by the cosine of the declination.
+    Units: ARCSECONDS PER HOUR
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/resources/gem/horizons/borrelly.eph
+++ b/modules/ephemeris/src/test/resources/gem/horizons/borrelly.eph
@@ -1,0 +1,202 @@
+*******************************************************************************
+JPL/HORIZONS                    19P/Borrelly               2017-Oct-03 07:55:49
+Rec #:900302          Soln.date: 2017-May-07_17:25:46   # obs: 2845 (1973-2017)
+
+IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+   A= 3.609665546424225    MA= 137.93043492053     ADIST= 5.859531354066144
+   PER= 6.8581765453391    N= .143715502           ANGMOM= .025557412
+   DAN= 1.36332            DDN= 5.79504            L= 69.6892033
+   B= -3.3504474           MOID= .377543           TP= 2001-Sep-14.2536303061
+
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+
+COMET comments
+1: soln ref.= JPL#K157/5, data arc: 1973-08-23 to 2017-03-30
+2: k1=17., k2=5., phase coef.=0.03;
+*******************************************************************************
+
+
+*******************************************************************************
+Ephemeris / WWW_USER Tue Oct  3 07:55:49 2017 Pasadena, USA      / Horizons
+*******************************************************************************
+Target body name: 19P/Borrelly                    {source: JPL#K157/5}
+Center body name: Earth (399)                     {source: DE431}
+Center-site name: Gemini South Obs., Cerro Pachon
+*******************************************************************************
+Start time      : A.D. 2017-Aug-15 00:00:00.0000 UT
+Stop  time      : A.D. 2017-Aug-15 23:59:00.0000 UT
+Step-size       : 50 steps
+*******************************************************************************
+Target pole/equ : IAU                             {East-longitude -}
+Target radii    : 4.2 x 4.2 x 4.2 km              {Equator, meridian, pole}
+Center geodetic : 289.263400,-30.240623,2.7123285 {E-lon(deg),Lat(deg),Alt(km)}
+Center cylindric: 289.263400,5517.21435,-3194.812 {E-lon(deg),Dxy(km),Dz(km)}
+Center pole/equ : High-precision EOP model        {East-longitude +}
+Center radii    : 6378.1 x 6378.1 x 6356.8 km     {Equator, meridian, pole}
+Target primary  : Sun
+Vis. interferer : MOON (R_eq= 1737.400) km        {source: DE431}
+Rel. light bend : Sun, EARTH                      {source: DE431}
+Rel. lght bnd GM: 1.3271E+11, 3.9860E+05 km^3/s^2
+Small-body perts: Yes                             {source: SB431-N16}
+Atmos refraction: NO (AIRLESS)
+RA format       : HMS
+Time format     : CAL
+RTS-only print  : NO
+EOP file        : eop.171002.p171224
+EOP coverage    : DATA-BASED 1962-JAN-20 TO 2017-OCT-02. PREDICTS-> 2017-DEC-23
+Units conversion: 1 au= 149597870.700 km, c= 299792.458 km/s, 1 day= 86400.0 s
+Table cut-offs 1: Elevation (-90.0deg=NO ),Airmass (>38.000=NO), Daylight (NO )
+Table cut-offs 2: Solar elongation (  0.0,180.0=NO ),Local Hour Angle( 0.0=NO )
+Table cut-offs 3: RA/DEC angular rate (     0.0=NO )
+*******************************************************************************
+Initial IAU76/J2000 heliocentric ecliptic osculating elements (au, days, deg.):
+  EPOCH=  2453126.5 ! 2004-May-01.0000000 (TDB)    RMSW= n.a.
+   EC= .6232892711821078   QR= 1.359799738782305   TP= 2452166.7536303061
+   OM= 75.43597686258941   W= 353.3506872274951    IN= 30.31307021679391
+  Equivalent ICRF heliocentric equatorial cartesian coordinates (au, au/d):
+   X=-2.901624145572271E+00  Y=-4.714098832558961E+00  Z=-1.011739942319315E+00
+  VX= 2.370889154078356E-03 VY=-2.679782026686279E-03 VZ=-3.223564467123717E-03
+Comet physical (GM= km^3/s^2; RAD= km):
+   GM= n.a.                RAD= 2.4
+   M1=  8.2      M2=  13.8     k1=  17.    k2=  5.      PHCOF=  .030
+Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+   AMRAT=  0.                                      DT=  -47.24577
+   A1= 1.895695477724E-9   A2= -7.833075709641E-11 A3= 2.85430829972E-10
+ Standard model:
+   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+*******************************************************************************
+ Date__(UT)__HR:MN:SC.fff     R.A.___(ICRF/J2000.0)___DEC dRA*cosD d(DEC)/dt
+****************************************************************************
+$$SOE
+ 2017-Aug-15 00:00:00.000     14 50 13.1823 -02 58 45.704 9.304921  -12.4881
+ 2017-Aug-15 00:28:46.800     14 50 13.4803 -02 58 51.699 9.338051  -12.4867
+ 2017-Aug-15 00:57:33.600     14 50 13.7794 -02 58 57.693 9.375816  -12.4855
+ 2017-Aug-15 01:26:20.400     14 50 14.0798 -02 59 03.686 9.417733  -12.4845
+ 2017-Aug-15 01:55:07.200     14 50 14.3816 -02 59 09.679 9.463256  -12.4837
+ 2017-Aug-15 02:23:54.000     14 50 14.6849 -02 59 15.671 9.511780  -12.4832
+ 2017-Aug-15 02:52:40.800     14 50 14.9897 -02 59 21.664 9.562654  -12.4830
+ 2017-Aug-15 03:21:27.600     14 50 15.2963 -02 59 27.656 9.615187  -12.4830
+ 2017-Aug-15 03:50:14.400     14 50 15.6045 -02 59 33.649 9.668666  -12.4834
+ 2017-Aug-15 04:19:01.200  s  14 50 15.9145 -02 59 39.642 9.722359  -12.4841
+ 2017-Aug-15 04:47:48.000     14 50 16.2262 -02 59 45.635 9.775534  -12.4851
+ 2017-Aug-15 05:16:34.800  m  14 50 16.5395 -02 59 51.629 9.827466  -12.4864
+ 2017-Aug-15 05:45:21.600  m  14 50 16.8545 -02 59 57.624 9.877449  -12.4880
+ 2017-Aug-15 06:14:08.400  m  14 50 17.1711 -03 00 03.619 9.924809  -12.4899
+ 2017-Aug-15 06:42:55.200  m  14 50 17.4891 -03 00 09.616 9.968913  -12.4920
+ 2017-Aug-15 07:11:42.000  m  14 50 17.8085 -03 00 15.613 10.00918  -12.4944
+ 2017-Aug-15 07:40:28.800  m  14 50 18.1291 -03 00 21.612 10.04509  -12.4970
+ 2017-Aug-15 08:09:15.600  m  14 50 18.4507 -03 00 27.612 10.07619  -12.4997
+ 2017-Aug-15 08:38:02.400  m  14 50 18.7733 -03 00 33.613 10.10210  -12.5026
+ 2017-Aug-15 09:06:49.200  m  14 50 19.0967 -03 00 39.616 10.12254  -12.5057
+ 2017-Aug-15 09:35:36.000  m  14 50 19.4205 -03 00 45.621 10.13730  -12.5087
+ 2017-Aug-15 10:04:22.800 Am  14 50 19.7448 -03 00 51.627 10.14625  -12.5119
+ 2017-Aug-15 10:33:09.600 Nm  14 50 20.0693 -03 00 57.634 10.14938  -12.5150
+ 2017-Aug-15 11:01:56.400 Cm  14 50 20.3938 -03 01 03.643 10.14676  -12.5181
+ 2017-Aug-15 11:30:43.200 *m  14 50 20.7181 -03 01 09.653 10.13853  -12.5210
+ 2017-Aug-15 11:59:30.000 *m  14 50 21.0420 -03 01 15.665 10.12495  -12.5239
+ 2017-Aug-15 12:28:16.800 *m  14 50 21.3654 -03 01 21.678 10.10635  -12.5266
+ 2017-Aug-15 12:57:03.600 *m  14 50 21.6882 -03 01 27.692 10.08314  -12.5291
+ 2017-Aug-15 13:25:50.400 *m  14 50 22.0102 -03 01 33.708 10.05581  -12.5314
+ 2017-Aug-15 13:54:37.200 *m  14 50 22.3312 -03 01 39.724 10.02491  -12.5335
+ 2017-Aug-15 14:23:24.000 *m  14 50 22.6512 -03 01 45.741 9.991028  -12.5353
+ 2017-Aug-15 14:52:10.800 *m  14 50 22.9700 -03 01 51.760 9.954834  -12.5368
+ 2017-Aug-15 15:20:57.600 *m  14 50 23.2877 -03 01 57.778 9.917012  -12.5380
+ 2017-Aug-15 15:49:44.400 *r  14 50 23.6041 -03 02 03.798 9.878277  -12.5389
+ 2017-Aug-15 16:18:31.200 *m  14 50 23.9193 -03 02 09.817 9.839359  -12.5394
+ 2017-Aug-15 16:47:18.000 *   14 50 24.2333 -03 02 15.837 9.800988  -12.5397
+ 2017-Aug-15 17:16:04.800 *   14 50 24.5461 -03 02 21.857 9.763889  -12.5396
+ 2017-Aug-15 17:44:51.600 *   14 50 24.8576 -03 02 27.876 9.728765  -12.5393
+ 2017-Aug-15 18:13:38.400 *   14 50 25.1682 -03 02 33.896 9.696287  -12.5386
+ 2017-Aug-15 18:42:25.200 *   14 50 25.4777 -03 02 39.915 9.667085  -12.5377
+ 2017-Aug-15 19:11:12.000 *   14 50 25.7863 -03 02 45.933 9.641736  -12.5366
+ 2017-Aug-15 19:39:58.800 *   14 50 26.0942 -03 02 51.951 9.620757  -12.5352
+ 2017-Aug-15 20:08:45.600 *   14 50 26.4015 -03 02 57.968 9.604596  -12.5337
+ 2017-Aug-15 20:37:32.400 *   14 50 26.7084 -03 03 03.985 9.593623  -12.5320
+ 2017-Aug-15 21:06:19.200 *   14 50 27.0150 -03 03 10.000 9.588128  -12.5302
+ 2017-Aug-15 21:35:06.000 *   14 50 27.3216 -03 03 16.015 9.588312  -12.5284
+ 2017-Aug-15 22:03:52.800 *t  14 50 27.6282 -03 03 22.029 9.594287  -12.5265
+ 2017-Aug-15 22:32:39.600 C   14 50 27.9351 -03 03 28.042 9.606074  -12.5246
+ 2017-Aug-15 23:01:26.400 N   14 50 28.2425 -03 03 34.054 9.623602  -12.5227
+ 2017-Aug-15 23:30:13.200 A   14 50 28.5505 -03 03 40.065 9.646707  -12.5210
+ 2017-Aug-15 23:59:00.000     14 50 28.8594 -03 03 46.075 9.675139  -12.5193
+$$EOE
+*******************************************************************************
+Column meaning:
+
+TIME
+
+  Prior to 1962, times are UT1. Dates thereafter are UTC. Any 'b' symbol in
+the 1st-column denotes a B.C. date. First-column blank (" ") denotes an A.D.
+date. Calendar dates prior to 1582-Oct-15 are in the Julian calendar system.
+Later calendar dates are in the Gregorian system.
+
+  Time tags refer to the same instant throughout the solar system, regardless
+of where the observer is located. For example, if an observation from the
+surface of another body has an output time-tag of 12:31:00 UTC, an Earth-based
+time-scale, it refers to the instant on that body simultaneous to 12:31:00 UTC
+on Earth.
+
+  The Barycentric Dynamical Time scale (TDB) is used internally as defined by
+the planetary equations of motion. Conversion between TDB and the selected
+non-uniform UT output time-scale has not been determined for UTC times after
+the next July or January 1st. The last known leap-second is used as a constant
+over future intervals.
+
+  NOTE: "n.a." in output means quantity "not available" at the print-time.
+
+SOLAR PRESENCE (OBSERVING SITE)
+  Time tag is followed by a blank, then a solar-presence symbol:
+
+        '*'  Daylight (refracted solar upper-limb on or above apparent horizon)
+        'C'  Civil twilight/dawn
+        'N'  Nautical twilight/dawn
+        'A'  Astronomical twilight/dawn
+        ' '  Night OR geocentric ephemeris
+
+LUNAR PRESENCE WITH TARGET RISE/TRANSIT/SET MARKER (OBSERVING SITE)
+  The solar-presence symbol is immediately followed by another marker symbol:
+
+        'm'  Refracted upper-limb of Moon on or above apparent horizon
+        ' '  Refracted upper-limb of Moon below apparent horizon OR geocentric
+        'r'  Rise    (target body on or above cut-off RTS elevation)
+        't'  Transit (target body at or past local maximum RTS elevation)
+        's'  Set     (target body on or below cut-off RTS elevation)
+
+RTS MARKERS (TVH)
+  Rise and set are with respect to the reference ellipsoid true visual horizon
+defined by the elevation cut-off angle. Horizon dip and yellow-light refraction
+(Earth only) are considered. Accuracy is < or = to twice the requested search
+step-size.
+
+ R.A.___(ICRF/J2000.0)___DEC =
+   J2000.0 astrometric right ascension and declination of target center.
+Adjusted for light-time. Units: HMS (HH MM SS.ffff) and DMS (DD MM SS.fff)
+
+ dRA*cosD d(DEC)/dt =
+    The rate of change of target center apparent RA and DEC (airless).
+d(RA)/dt is multiplied by the cosine of the declination.
+    Units: ARCSECONDS PER HOUR
+
+
+ Computations by ...
+     Solar System Dynamics Group, Horizons On-Line Ephemeris System
+     4800 Oak Grove Drive, Jet Propulsion Laboratory
+     Pasadena, CA  91109   USA
+     Information: http://ssd.jpl.nasa.gov/
+     Connect    : telnet://ssd.jpl.nasa.gov:6775  (via browser)
+                  telnet ssd.jpl.nasa.gov 6775    (via command-line)
+     Author     : Jon.D.Giorgini@jpl.nasa.gov
+
+*******************************************************************************

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
@@ -1,0 +1,169 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+import gem.enum.Site.GN
+import gem.math.Ephemeris
+import gem.test.RespectIncludeTags
+import gem.test.Tags._
+
+import EphemerisCompression._
+
+import cats.effect.Blocker
+import cats.effect.IO
+import cats.implicits._
+import cats.tests.CatsSuite
+
+import fs2.Pipe
+
+import java.time.{ LocalDate, Month }
+import java.time.temporal.ChronoUnit.MINUTES
+
+@org.scalatest.Ignore
+final class EphemerisCompressionSpec extends CatsSuite with EphemerisTestSupport with RespectIncludeTags {
+  import EphemerisCompressionSpec._
+
+  test("compresses") {
+    val a = Blocker[IO].use(stream("borrelly", _)
+              .through(EphemerisParser.elements[IO])
+              .through(standardVelocityCompression).compile.toVector)
+
+    val e = Blocker[IO].use(stream("borrelly-compressed", _)
+              .through(EphemerisParser.elements[IO]).compile.toVector)
+
+    val actual   = a.unsafeRunSync
+    val expected = e.unsafeRunSync
+
+    assert(actual == expected)
+  }
+
+  val Δv: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardVelocityCompression
+  val ac: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardAccelerationCompression
+
+  test("2014 UR Δv compresses to 100% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
+    val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
+
+    testCompression("2014 UR Δv", ur_2014, 1.00, start, end, Δv)
+  }
+
+  test("2014 UR a compresses to 10.1% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
+    val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
+
+    testCompression("2014 UR a", ur_2014, 0.101, start, end, ac)
+  }
+
+  test("2015 QT3 Δv compresses to 34% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.AUGUST,  1)
+    val end   = LocalDate.of(2015, Month.OCTOBER, 1)
+
+    testCompression("2015 QT3 Δv", qt3_2015, 0.342, start, end, Δv)
+  }
+
+  test("2015 QT3 a compresses to 5.6% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.AUGUST,  1)
+    val end   = LocalDate.of(2015, Month.OCTOBER, 1)
+
+    testCompression("2015 QT3 a", qt3_2015, 0.056, start, end, ac)
+  }
+
+  test("Churyumov-Gerasimenko Δv compresses to 4% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.DECEMBER, 15)
+    val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
+
+    testCompression("Churyumov Δv", churyumov, 0.039, start, end, Δv)
+  }
+
+  test("Churyumov-Gerasimenko a compresses to 1.2% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.DECEMBER, 15)
+    val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
+
+    testCompression("Churyumov a", churyumov, 0.012, start, end, ac)
+  }
+
+  test("Titan Δv compresses to 1% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.JULY  ,    1)
+    val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
+
+    testCompression("Titan Δv", titan, 0.008, start, end, Δv)
+  }
+
+  test("Titan a compresses to 0.6% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.JULY  ,    1)
+    val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
+
+    testCompression("Titan a", titan, 0.006, start, end, ac)
+  }
+
+  test("Beer Δv compresses to 5% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.OCTOBER,  1)
+    val end   = LocalDate.of(2015, Month.DECEMBER, 1)
+
+    testCompression("Beer Δv", beer, 0.046, start, end, Δv)
+  }
+
+  test("Beer a compresses to 1.4% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.OCTOBER,  1)
+    val end   = LocalDate.of(2015, Month.DECEMBER, 1)
+
+    testCompression("Beer a", beer, 0.014, start, end, ac)
+  }
+
+  test("Io Δv compresses to 24% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.MARCH, 1)
+    val end   = LocalDate.of(2015, Month.MAY,   1)
+
+    testCompression("Io Δv", io, 0.237, start, end, Δv)
+  }
+
+  test("Io a compresses to 3.2% of original size", RequiresNetwork) {
+    val start = LocalDate.of(2015, Month.MARCH, 1)
+    val end   = LocalDate.of(2015, Month.MAY,   1)
+
+    testCompression("Io a", io, 0.032, start, end, ac)
+  }
+
+  def testCompression(
+        name:          String,
+        key:           EphemerisKey.Horizons,
+        expectedRatio: Double,
+        start:         LocalDate,
+        end:           LocalDate,
+        pipe:          Pipe[IO, Ephemeris.Element, Ephemeris.Element]): org.scalatest.Assertion = {
+
+    // Start and end at midnight local time.
+    val zstart = start.atTime(0, 0).atZone(GN.timezone)
+    val zend   = end.atTime(0, 0).atZone(GN.timezone)
+
+    // One element per minute
+    val elems  = zstart.until(zend, MINUTES).toInt
+
+    val e      = HorizonsEphemerisQuery(key, GN, zstart.toInstant, zend.toInstant, elems).exec(pipe)
+    val size   = e.toMap.size
+    val ratio  = size.toDouble / elems.toDouble
+
+    println(f"$name%-12s $key%-21s => $size%5d / $elems%5d elements, ${ratio * 100.0}%5.2f%% of original")
+
+    assert((ratio >= expectedRatio - 0.001) &&
+           (ratio <= expectedRatio + 0.001))
+  }
+}
+
+object EphemerisCompressionSpec {
+  private val beer      = EphemerisKey.AsteroidNew("1971 UC1")
+  private val churyumov = EphemerisKey.Comet("67P")
+  private val io        = EphemerisKey.MajorBody(501)
+  private val titan     = EphemerisKey.MajorBody(606)
+  private val qt3_2015  = EphemerisKey.AsteroidNew("2015 QT3")
+  private val ur_2014   = EphemerisKey.AsteroidNew("2014 UR")
+
+  implicit class QueryOps(q: HorizonsEphemerisQuery) {
+    def exec(compression: Pipe[IO, Ephemeris.Element, Ephemeris.Element]): Ephemeris = {
+      val s = q.streamEphemeris.through(compression)
+      Ephemeris.fromFoldable[Vector](s.compile.toVector.unsafeRunSync)
+    }
+  }
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
@@ -41,84 +41,84 @@ final class EphemerisCompressionSpec extends CatsSuite with EphemerisTestSupport
   val Δv: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardVelocityCompression
   val ac: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardAccelerationCompression
 
-  ignore("2014 UR Δv compresses to 100% of original size", RequiresNetwork) {
+  test("2014 UR Δv compresses to 100% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
     val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
 
     testCompression("2014 UR Δv", ur_2014, 1.00, start, end, Δv)
   }
 
-  ignore("2014 UR a compresses to 10.1% of original size", RequiresNetwork) {
+  test("2014 UR a compresses to 10.1% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
     val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
 
     testCompression("2014 UR a", ur_2014, 0.101, start, end, ac)
   }
 
-  ignore("2015 QT3 Δv compresses to 34% of original size", RequiresNetwork) {
+  test("2015 QT3 Δv compresses to 34% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.AUGUST,  1)
     val end   = LocalDate.of(2015, Month.OCTOBER, 1)
 
     testCompression("2015 QT3 Δv", qt3_2015, 0.342, start, end, Δv)
   }
 
-  ignore("2015 QT3 a compresses to 5.6% of original size", RequiresNetwork) {
+  test("2015 QT3 a compresses to 5.6% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.AUGUST,  1)
     val end   = LocalDate.of(2015, Month.OCTOBER, 1)
 
     testCompression("2015 QT3 a", qt3_2015, 0.056, start, end, ac)
   }
 
-  ignore("Churyumov-Gerasimenko Δv compresses to 4% of original size", RequiresNetwork) {
+  test("Churyumov-Gerasimenko Δv compresses to 4% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.DECEMBER, 15)
     val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
 
     testCompression("Churyumov Δv", churyumov, 0.039, start, end, Δv)
   }
 
-  ignore("Churyumov-Gerasimenko a compresses to 1.2% of original size", RequiresNetwork) {
+  test("Churyumov-Gerasimenko a compresses to 1.2% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.DECEMBER, 15)
     val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
 
     testCompression("Churyumov a", churyumov, 0.012, start, end, ac)
   }
 
-  ignore("Titan Δv compresses to 1% of original size", RequiresNetwork) {
+  test("Titan Δv compresses to 1% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.JULY  ,    1)
     val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
 
     testCompression("Titan Δv", titan, 0.008, start, end, Δv)
   }
 
-  ignore("Titan a compresses to 0.6% of original size", RequiresNetwork) {
+  test("Titan a compresses to 0.6% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.JULY  ,    1)
     val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
 
     testCompression("Titan a", titan, 0.006, start, end, ac)
   }
 
-  ignore("Beer Δv compresses to 5% of original size", RequiresNetwork) {
+  test("Beer Δv compresses to 5% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.OCTOBER,  1)
     val end   = LocalDate.of(2015, Month.DECEMBER, 1)
 
     testCompression("Beer Δv", beer, 0.046, start, end, Δv)
   }
 
-  ignore("Beer a compresses to 1.4% of original size", RequiresNetwork) {
+  test("Beer a compresses to 1.4% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.OCTOBER,  1)
     val end   = LocalDate.of(2015, Month.DECEMBER, 1)
 
     testCompression("Beer a", beer, 0.014, start, end, ac)
   }
 
-  ignore("Io Δv compresses to 24% of original size", RequiresNetwork) {
+  test("Io Δv compresses to 24% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.MARCH, 1)
     val end   = LocalDate.of(2015, Month.MAY,   1)
 
     testCompression("Io Δv", io, 0.237, start, end, Δv)
   }
 
-  ignore("Io a compresses to 3.2% of original size", RequiresNetwork) {
+  test("Io a compresses to 3.2% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.MARCH, 1)
     val end   = LocalDate.of(2015, Month.MAY,   1)
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisCompressionSpec.scala
@@ -21,7 +21,6 @@ import fs2.Pipe
 import java.time.{ LocalDate, Month }
 import java.time.temporal.ChronoUnit.MINUTES
 
-@org.scalatest.Ignore
 final class EphemerisCompressionSpec extends CatsSuite with EphemerisTestSupport with RespectIncludeTags {
   import EphemerisCompressionSpec._
 
@@ -42,84 +41,84 @@ final class EphemerisCompressionSpec extends CatsSuite with EphemerisTestSupport
   val Δv: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardVelocityCompression
   val ac: Pipe[IO, Ephemeris.Element, Ephemeris.Element] = standardAccelerationCompression
 
-  test("2014 UR Δv compresses to 100% of original size", RequiresNetwork) {
+  ignore("2014 UR Δv compresses to 100% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
     val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
 
     testCompression("2014 UR Δv", ur_2014, 1.00, start, end, Δv)
   }
 
-  test("2014 UR a compresses to 10.1% of original size", RequiresNetwork) {
+  ignore("2014 UR a compresses to 10.1% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.SEPTEMBER, 15)
     val end   = LocalDate.of(2015, Month.NOVEMBER,  15)
 
     testCompression("2014 UR a", ur_2014, 0.101, start, end, ac)
   }
 
-  test("2015 QT3 Δv compresses to 34% of original size", RequiresNetwork) {
+  ignore("2015 QT3 Δv compresses to 34% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.AUGUST,  1)
     val end   = LocalDate.of(2015, Month.OCTOBER, 1)
 
     testCompression("2015 QT3 Δv", qt3_2015, 0.342, start, end, Δv)
   }
 
-  test("2015 QT3 a compresses to 5.6% of original size", RequiresNetwork) {
+  ignore("2015 QT3 a compresses to 5.6% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.AUGUST,  1)
     val end   = LocalDate.of(2015, Month.OCTOBER, 1)
 
     testCompression("2015 QT3 a", qt3_2015, 0.056, start, end, ac)
   }
 
-  test("Churyumov-Gerasimenko Δv compresses to 4% of original size", RequiresNetwork) {
+  ignore("Churyumov-Gerasimenko Δv compresses to 4% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.DECEMBER, 15)
     val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
 
     testCompression("Churyumov Δv", churyumov, 0.039, start, end, Δv)
   }
 
-  test("Churyumov-Gerasimenko a compresses to 1.2% of original size", RequiresNetwork) {
+  ignore("Churyumov-Gerasimenko a compresses to 1.2% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.DECEMBER, 15)
     val end   = LocalDate.of(2016, Month.FEBRUARY, 15)
 
     testCompression("Churyumov a", churyumov, 0.012, start, end, ac)
   }
 
-  test("Titan Δv compresses to 1% of original size", RequiresNetwork) {
+  ignore("Titan Δv compresses to 1% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.JULY  ,    1)
     val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
 
     testCompression("Titan Δv", titan, 0.008, start, end, Δv)
   }
 
-  test("Titan a compresses to 0.6% of original size", RequiresNetwork) {
+  ignore("Titan a compresses to 0.6% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.JULY  ,    1)
     val end   = LocalDate.of(2015, Month.SEPTEMBER, 1)
 
     testCompression("Titan a", titan, 0.006, start, end, ac)
   }
 
-  test("Beer Δv compresses to 5% of original size", RequiresNetwork) {
+  ignore("Beer Δv compresses to 5% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.OCTOBER,  1)
     val end   = LocalDate.of(2015, Month.DECEMBER, 1)
 
     testCompression("Beer Δv", beer, 0.046, start, end, Δv)
   }
 
-  test("Beer a compresses to 1.4% of original size", RequiresNetwork) {
+  ignore("Beer a compresses to 1.4% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.OCTOBER,  1)
     val end   = LocalDate.of(2015, Month.DECEMBER, 1)
 
     testCompression("Beer a", beer, 0.014, start, end, ac)
   }
 
-  test("Io Δv compresses to 24% of original size", RequiresNetwork) {
+  ignore("Io Δv compresses to 24% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.MARCH, 1)
     val end   = LocalDate.of(2015, Month.MAY,   1)
 
     testCompression("Io Δv", io, 0.237, start, end, Δv)
   }
 
-  test("Io a compresses to 3.2% of original size", RequiresNetwork) {
+  ignore("Io a compresses to 3.2% of original size", RequiresNetwork) {
     val start = LocalDate.of(2015, Month.MARCH, 1)
     val end   = LocalDate.of(2015, Month.MAY,   1)
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisParserSpec.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.{ Ephemeris, EphemerisCoordinates }
+import gsp.math.syntax.treemap._
+import gem.util.Timestamp
+
+import cats.effect.Blocker
+import cats.effect.IO
+import cats.tests.CatsSuite
+
+import fs2.Stream
+
+import scala.collection.immutable.TreeMap
+
+
+/** Not really a spec per se, but rather a way to exercise the ephemeris parser
+  * with a few fixed examples and get a sense of whether it works.
+  */
+final class EphemerisParserSpec extends CatsSuite with EphemerisTestSupport {
+
+  test("Must parse") {
+
+    val head = eph(
+      "2017-Aug-15 00:00:00.000" -> (("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")),
+      "2017-Aug-15 00:28:46.800" -> (("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")),
+      "2017-Aug-15 00:57:33.600" -> (("14 50 13.7794 -02 58 57.693", "9.375816", "-12.4855"))
+    )
+
+    val tail = eph(
+      "2017-Aug-15 23:01:26.400" -> (("14 50 28.2425 -03 03 34.054", "9.623602", "-12.5227")),
+      "2017-Aug-15 23:30:13.200" -> (("14 50 28.5505 -03 03 40.065", "9.646707", "-12.5210")),
+      "2017-Aug-15 23:59:00.000" -> (("14 50 28.8594 -03 03 46.075", "9.675139", "-12.5193"))
+    )
+
+    checkParse("borrelly", head, tail)
+  }
+
+  private def checkParse(
+    name: String,
+    head: TreeMap[Timestamp, EphemerisCoordinates],
+    tail: TreeMap[Timestamp, EphemerisCoordinates]
+  ): org.scalatest.Assertion = {
+
+    val e = EphemerisParser.parse(load(name)).option.getOrElse(Ephemeris.empty)
+
+    // This works but the error message isn't helpful when it fails.  There
+    // should be a way to combine shouldEqual assertions ...
+    assert(
+      (e.toMap.size                == 51  ) &&
+      (e.toMap.to(head.lastKey)    == head) &&
+      (e.toMap.from(tail.firstKey) == tail)
+    )
+  }
+
+  test("Must stream") {
+    val head = eph(
+      "2017-Aug-15 00:00:00.000" -> (("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")),
+      "2017-Aug-15 00:28:46.800" -> (("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")),
+      "2017-Aug-15 00:57:33.600" -> (("14 50 13.7794 -02 58 57.693", "9.375816", "-12.4855"))
+    )
+
+    val s = Blocker[IO].use(stream("borrelly", _).through(EphemerisParser.elements[IO]).take(head.size.toLong).compile.toVector)
+    val m = TreeMap.fromFoldable(s.unsafeRunSync)
+
+    assert(m == head)
+  }
+
+  test("Must handle errors") {
+    val z = Timestamp.Min -> EphemerisCoordinates.Zero
+    val s = Blocker[IO].use(stream("borrelly-error", _)
+             .through(EphemerisParser.elements[IO])
+             .handleErrorWith(_ => Stream(z)).last.compile.toVector)
+    assert(Vector(Some(z)) == s.unsafeRunSync)
+  }
+
+  test("Must stream eitherElements") {
+    val head = Vector[Either[String, Ephemeris.Element]](
+      Right(time("2017-Aug-15 00:00:00.000") -> ephCoords("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")),
+      Right(time("2017-Aug-15 00:28:46.800") -> ephCoords("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")),
+      Left("Failure reading:solarPresence")
+    )
+
+    val s = Blocker[IO].use(stream("borrelly-error", _).through(EphemerisParser.eitherElements[IO]).take(head.size.toLong).compile.toVector)
+    val m = s.unsafeRunSync()
+
+    assert(m == head)
+  }
+
+  test("Must stream validElements") {
+    val head = eph(
+      "2017-Aug-15 00:00:00.000" -> (("14 50 13.1823 -02 58 45.704", "9.304921", "-12.4881")), // 0
+      "2017-Aug-15 00:28:46.800" -> (("14 50 13.4803 -02 58 51.699", "9.338051", "-12.4867")), // 1
+      "2017-Aug-15 01:26:20.400" -> (("14 50 14.0798 -02 59 03.686", "9.417733", "-12.4845"))  // 3 (skipping 2)
+    )
+
+    val s = Blocker[IO].use(stream("borrelly-error", _).through(EphemerisParser.validElements[IO]).take(head.size.toLong).compile.toVector)
+    val m = TreeMap.fromFoldable(s.unsafeRunSync)
+
+    assert(m == head)
+  }
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/EphemerisTestSupport.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.math.EphemerisCoordinates
+import gsp.math.{ Angle, Coordinates, Offset }
+import gsp.math.syntax.treemap._
+import gem.util.Timestamp
+
+import cats.effect.{ Blocker, IO, ContextShift }
+import fs2.Stream
+
+import java.io.InputStream
+import java.time.{ LocalDateTime, ZoneOffset }
+import java.time.format.DateTimeFormatter
+
+import scala.collection.immutable.TreeMap
+import scala.io.Source
+
+
+trait EphemerisTestSupport {
+
+  private implicit val contextShift: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  val TimeFormat: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSS")
+
+  def time(s: String): Timestamp =
+    Timestamp.unsafeFromInstant(LocalDateTime.parse(s, TimeFormat).toInstant(ZoneOffset.UTC))
+
+  def coords(s: String): Coordinates =
+    Coordinates.fromHmsDms.getOption(s).getOrElse(Coordinates.Zero)
+
+  def arcsec(s: String): Angle =
+    Angle.fromMicroarcseconds(BigDecimal(s).underlying.movePointRight(6).longValueExact)
+
+  def offsetp(s: String): Offset.P =
+    Offset.P(arcsec(s))
+
+  def offsetq(s: String): Offset.Q =
+    Offset.Q(arcsec(s))
+
+  def ephCoords(c: String, p: String, q: String): EphemerisCoordinates =
+    EphemerisCoordinates(coords(c), Offset(offsetp(p), offsetq(q)))
+
+  def eph(elems: (String, (String, String, String))*): TreeMap[Timestamp, EphemerisCoordinates] =
+    TreeMap.fromList(elems.toList.map { case (i, (c, p, q)) => time(i) -> ephCoords(c, p, q) })
+
+  def inputStream(n: String): InputStream =
+    getClass.getResourceAsStream(s"$n.eph")
+
+  def stream(n: String, b: Blocker): Stream[IO, String] =
+    fs2.io.readInputStream(IO(inputStream(n)), 128, b)
+          .through(fs2.text.utf8Decode)
+
+  def load(n: String): String =
+    Source.fromInputStream(inputStream(n)).mkString
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsClientSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsClientSpec.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import cats.effect.{ IO, ContextShift }
+import cats.tests.CatsSuite
+import fs2.Stream
+
+final class HorizonsClientSpec extends CatsSuite {
+
+  private implicit val contextShift: ContextShift[IO] =
+    IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  def exclusionTest(s: Stream[IO, _]): Boolean = {
+    val count = 20
+    val instrumented = { var x = 0; s.flatMap(_ => Stream.eval(IO { x += 1; Thread.sleep(10); x })) }
+    val cs = Stream(instrumented).repeat.covary[IO].take(count.toLong)
+    cs.parJoinUnbounded.compile.toVector.unsafeRunSync == (1 to count).toList
+  }
+
+  test("Arbitrary IO should be parallel.") {
+    assert(!exclusionTest(Stream.eval(IO.unit)))
+  }
+
+  // Have to turn this off for now
+//  test("Access to client should be serial.") {
+//    assert(exclusionTest(HorizonsClient.client))
+//  }
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQueryPagingPropSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQueryPagingPropSpec.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+import gem.enum.Site.GS
+import gsp.math.arb.ArbTime._
+import gsp.math.syntax.time._
+
+import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.Arbitrary.arbitrary
+
+import java.time.{ Duration, Instant }
+
+import scala.math.Ordering.Implicits._
+import cats.tests.CatsSuite
+
+
+class HorizonsEphemerisQueryPagingPropSpec extends CatsSuite {
+
+  import HorizonsEphemerisQueryPagingPropSpec._
+
+  case class TestCase(start: Instant, end: Instant, step: Duration) {
+
+    val paging: List[HorizonsEphemerisQuery] =
+      HorizonsEphemerisQuery.paging(titan, GS, start, end, step)
+  }
+
+  // Generate reasonable test cases that don't ask for trillions of queries
+  implicit val arbTestCase: Arbitrary[TestCase] =
+    Arbitrary {
+      for {
+        s <- arbitrary[Instant]
+        d <- arbitrary[Duration].map(_.abs)
+        c <- Gen.choose(1, 1000000) // steps
+        f <- Gen.choose(0.0, 1.0)
+        dʹ = HorizonsEphemerisQuery.MinStepLen max (d / ms.toNanos * ms.toNanos)
+        e  = s + dʹ * c.toLong + Duration.ofMillis((dʹ.toMillis * f).round)
+      } yield TestCase(s, e, dʹ)
+    }
+
+  test("queries should be contiguous") {
+    forAll { (t: TestCase) =>
+      val times = t.paging.map(q => (q.startTime, q.endTime))
+
+      (times.zip(times.drop(1)).forall { case ((_, e), (s, _)) =>
+          e + t.step == s
+      }) shouldBe true
+    }
+  }
+
+  test("last element should be less than two step sizes away from end") {
+    forAll { (t: TestCase) =>
+      t.paging.lastOption match {
+        case None    => fail
+        case Some(q) => q.endTime should (be >= t.end and be < (t.end + t.step * 2))
+      }
+    }
+  }
+
+  test("explicitly handle case where last page would have one element using MaxElement-sized pages") {
+    // This was a failing randomly generated test case, so we'll leave it as a test.
+    val s = Instant.parse("2003-10-24T03:53:56.396546622Z")
+    val e = Instant.parse("2003-11-28T00:22:17.151546622Z")
+    val d = Duration.parse("PT6.69S")
+    val t = TestCase(s, e, d)
+    t.paging.lastOption match {
+      case None    => fail
+      case Some(q) => q.endTime should (be >= t.end and be < (t.end + t.step * 2))
+    }
+  }
+
+  test("first element should be exactly at start time") {
+    forAll { (t: TestCase) =>
+      t.paging.headOption match {
+        case None    => fail
+        case Some(q) => q.startTime shouldEqual t.start
+      }
+    }
+  }
+
+  test("each element is spaced exactly by duration") {
+    forAll { (t: TestCase) =>
+      val stepMs = t.step.toMillis
+      val ds     = t.paging.map(q => (Duration.between(q.startTime, q.endTime).toMillis, q.elementLimit))
+
+      (ds.forall { case (dMs, cnt) =>
+        (dMs % stepMs == 0) && ((dMs / stepMs) + 1 == cnt.toLong)
+      }) shouldBe true
+    }
+  }
+}
+
+object HorizonsEphemerisQueryPagingPropSpec {
+
+  private val titan = EphemerisKey.MajorBody(606)
+  private val ms    = Duration.ofMillis(1)
+
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsEphemerisQuerySpec.scala
@@ -1,0 +1,176 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.EphemerisKey
+import gem.enum.Site.GS
+import gem.math.Ephemeris
+import gem.test.RespectIncludeTags
+import gem.test.Tags._
+import gem.util.Timestamp
+import gsp.math.syntax.time._
+
+import cats.implicits._
+import cats.tests.CatsSuite
+
+import java.time.{ Duration, Instant, LocalDateTime, Month }
+import java.time.ZoneOffset.UTC
+import java.time.temporal.ChronoUnit.DAYS
+
+/** Exercises HorizonsEphemerisQuery.  Because the tests require accessing an
+  * external service, they are tagged with "RequiresNetwork" and usually skipped
+  * See the build.sbt where RequiresNetwork tests are excluded via the setting:
+  *
+  *     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork")
+  *
+  */
+final class HorizonsEphemerisQuerySpec extends CatsSuite with EphemerisTestSupport with RespectIncludeTags {
+
+  import HorizonsEphemerisQuerySpec._
+
+  test("simple query should work", RequiresNetwork) {
+    val e = HorizonsEphemerisQuery(titan, GS, start, end, 60).exec()
+
+    assert(
+      e.first.exists(_ == (startM -> startCoords)) &&
+      e.last .exists(_ == (endM   -> endCoords  )) &&
+      e.toMap.size == 60
+    )
+  }
+
+  test("at least 2 values are returned (start and end)", RequiresNetwork) {
+    val e = HorizonsEphemerisQuery(titan, GS, start, end, -1).exec()
+
+    assert(
+      e.first.exists(_ == (startM -> startCoords)) &&
+      e.last .exists(_ == (endM   -> endCoords  )) &&
+      e.toMap.size == 2
+    )
+  }
+
+  test("caps requests at MaxElements", RequiresNetwork, Slow) {
+    val e = HorizonsEphemerisQuery(titan, GS, start, end.plus(182, DAYS), HorizonsEphemerisQuery.MaxElements + 1).exec()
+
+    assert(e.toMap.size == HorizonsEphemerisQuery.MaxElements)
+  }
+
+  test("returns nothing if end comes before start", RequiresNetwork) {
+    val e = HorizonsEphemerisQuery(titan, GS, end, start, 60).exec()
+
+    assert(e.toMap.size == 0)
+  }
+
+  private def checkPaging(start: Instant, end: Instant, expected: HorizonsEphemerisQuery*): org.scalatest.Assertion = {
+    val as = HorizonsEphemerisQuery.paging(titan, GS, start, end, OneMinute)
+    val es = expected.toList
+
+    assert(es.size == as.size && es.zip(as).forall { case (e, a) =>
+      e.startTime    == a.startTime    &&
+      e.endTime      == a.endTime      &&
+      e.elementLimit == a.elementLimit
+    })
+  }
+
+  val Max: Int = HorizonsEphemerisQuery.MaxElements
+
+  test("paging a negative time amount should be empty") {
+    checkPaging(end, start)
+  }
+
+  test("paging a zero time amount should be empty") {
+    checkPaging(start, start)
+  }
+
+  test("paging less time than the step size should produce two elements, one query") {
+    checkPaging(
+      start,
+      start + Duration.ofNanos(1),
+      HorizonsEphemerisQuery(titan, GS, start, start + OneMinute, 2)
+    )
+  }
+
+  test("paging a time that requires < MaxElements should result in one query") {
+    checkPaging(
+      start,
+      end,
+      HorizonsEphemerisQuery(titan, GS, start, end, 61)
+    )
+  }
+
+  test("paging exactly MaxElements should result in a single query") {
+    val end = start + OneMinute * (Max.toLong - 1L) // remember *inclusive*
+
+    checkPaging(
+      start,
+      end,
+      HorizonsEphemerisQuery(titan, GS, start, end, Max)
+    )
+  }
+
+  test("paging MaxElements + 1 should result in two queries") {
+
+    // Produces Max + 1 elements because end is inclusive.
+    val end = start + OneMinute * Max.toLong
+
+    checkPaging(
+      start,
+      end,
+      // Here the first query has Max elements.  The second query would have
+      // just one element but since that won't work with horizons it is extended
+      // to include an additional element.
+      HorizonsEphemerisQuery(titan, GS, start, end - OneMinute, Max),
+      HorizonsEphemerisQuery(titan, GS, end,   end + OneMinute,   2)
+    )
+  }
+
+  test("paging MaxElements + 2 should result in two queries") {
+
+    // Produces Max + 2 elements because end is inclusive
+    val end = start + OneMinute * (Max + 1).toLong
+
+    checkPaging(
+      start,
+      end,
+      // The first query can contain a full MaxElements page because the second
+      // query will pick up the remaining two.
+      HorizonsEphemerisQuery(titan, GS, start,           end - OneMinute * 2L, Max),
+      HorizonsEphemerisQuery(titan, GS, end - OneMinute, end,                  2  )
+    )
+  }
+
+  test("paging MaxElements + 3 should result in two queries") {
+
+    // Produces Max + 3 elements because end is inclusive
+    val end = start + OneMinute * (Max + 2).toLong
+
+    checkPaging(
+      start,
+      end,
+      // The first query can contain a full MaxElements page because the second
+      // query will pick up the remaining three.
+      HorizonsEphemerisQuery(titan, GS, start,                end - OneMinute * 3L, Max),
+      HorizonsEphemerisQuery(titan, GS, end - OneMinute * 2L, end,                  3  )
+    )
+  }
+}
+
+object HorizonsEphemerisQuerySpec extends EphemerisTestSupport {
+  private val titan = EphemerisKey.MajorBody(606)
+
+  private val start = LocalDateTime.of(2017, Month.AUGUST, 15, 1, 0).toInstant(UTC)
+  private val end   = LocalDateTime.of(2017, Month.AUGUST, 15, 2, 0).toInstant(UTC)
+
+  private val startM      = Timestamp.unsafeFromInstant(start)
+  private val endM        = Timestamp.unsafeFromInstant(end)
+
+  private val startCoords = ephCoords("17:21:29.110300 -21:55:46.509000", "-2.85225", "-1.61124")
+  private val endCoords   = ephCoords("17:21:28.904000 -21:55:48.103000", "-2.87880", "-1.58756")
+
+  private val OneMinute   = Duration.ofMinutes(1)
+
+  implicit class QueryOps(q: HorizonsEphemerisQuery) {
+    def exec(): Ephemeris =
+      Ephemeris.fromFoldable[Vector](q.streamEphemeris.compile.toVector.unsafeRunSync)
+  }
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
@@ -1,0 +1,122 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.test.RespectIncludeTags
+import gem.test.Tags._
+
+import gem.{ EphemerisKey => EK }
+
+import cats.tests.CatsSuite
+
+import scala.util.Either
+
+final class HorizonsNameQuerySpec extends CatsSuite with RespectIncludeTags {
+  import HorizonsNameQuery._
+
+  def runSearch[A](s: Search[A]): Either[Error, List[Resolution[A]]] =
+    HorizonsNameQuery(s).lookup.value.unsafeRunSync
+
+  test("comet search should handle empty results", RequiresNetwork) {
+    runSearch(Search.Comet("covfefe")) shouldEqual Nil.asRight
+  }
+
+  test("comet search should handle multiple results", RequiresNetwork) {
+    runSearch(Search.Comet("hu")).map(_.take(5)) shouldEqual List(
+      Resolution(EK.Comet("67P"), "Churyumov-Gerasimenko"),
+      Resolution(EK.Comet("106P"), "Schuster"),
+      Resolution(EK.Comet("130P"), "McNaught-Hughes"),
+      Resolution(EK.Comet("178P"), "Hug-Bell"),
+      Resolution(EK.Comet("C/1880 Y1"), "Pechule")
+    ).asRight
+  }
+
+  test("comet search should handle single result (Format 1) Hubble (C/1937 P1)", RequiresNetwork) {
+    runSearch(Search.Comet("hubble")) shouldEqual List(
+      Resolution(EK.Comet("C/1937 P1"), "Hubble")
+    ).asRight
+  }
+
+  test("comet search should handle single result (Format 2) 1P/Halley pattern", RequiresNetwork) {
+    runSearch(Search.Comet("halley")) shouldEqual List(
+      Resolution(EK.Comet("1P"), "Halley")
+    ).asRight
+  }
+
+  test("asteroid search should handle empty results", RequiresNetwork) {
+    runSearch(Search.Asteroid("covfefe")) shouldEqual Nil.asRight
+  }
+
+  test("asteroid search should handle multiple results", RequiresNetwork) {
+    runSearch(Search.Asteroid("her")).map(_.take(5)) shouldEqual List(
+      Resolution(EK.AsteroidOld(103), "Hera"),
+      Resolution(EK.AsteroidOld(121), "Hermione"),
+      Resolution(EK.AsteroidOld(135), "Hertha"),
+      Resolution(EK.AsteroidOld(206), "Hersilia"),
+      Resolution(EK.AsteroidOld(214), "Aschera")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 1) 90377 Sedna (2003 VB12)", RequiresNetwork) {
+    runSearch(Search.Asteroid("sedna")) shouldEqual List(
+      Resolution(EK.AsteroidNew("2003 VB12"), "Sedna")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 2) 29 Amphitrite", RequiresNetwork) {
+    runSearch(Search.Asteroid("amphitrite")) shouldEqual List(
+      Resolution(EK.AsteroidOld(29), "Amphitrite")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 3) (2016 GB222)", RequiresNetwork) {
+    runSearch(Search.Asteroid("2016 GB222")) shouldEqual List(
+      Resolution(EK.AsteroidNew("2016 GB222"), "2016 GB222")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 4) 418993 (2009 MS9)", RequiresNetwork) {
+    runSearch(Search.Asteroid("2009 MS9")) shouldEqual List(
+      Resolution(EK.AsteroidNew("2009 MS9"), "2009 MS9")
+    ).asRight
+  }
+
+  test("asteroid search should handle single result (Format 5) 1I/'Oumuamua (A/2017 U1)", RequiresNetwork) {
+    runSearch(Search.Asteroid("A/2017 U1")) shouldEqual List(
+      Resolution(EK.AsteroidNew("A/2017 U1"), "A/2017 U1")
+    ).asRight
+  }
+
+  test("major body search should handle empty results", RequiresNetwork) {
+    runSearch(Search.MajorBody("covfefe")) shouldEqual Nil.asRight
+  }
+
+  ignore("major body search should handle empty results with small-body fallthrough (many)", RequiresNetwork) {
+    runSearch(Search.MajorBody("hu")) shouldEqual Nil.asRight
+  }
+
+  test("major body search should handle empty results with small-body fallthrough (single)", RequiresNetwork) {
+    runSearch(Search.MajorBody("hermione")) shouldEqual Nil.asRight
+  }
+
+  test("major body search should handle multiple results", RequiresNetwork) {
+    runSearch(Search.MajorBody("mar")).map(_.take(5)) shouldEqual List(
+      Resolution(EK.MajorBody(4), "Mars Barycenter"),
+      Resolution(EK.MajorBody(499), "Mars"),
+      Resolution(EK.MajorBody(723), "Margaret")
+    ).asRight
+  }
+
+  test("major body search should handle single result with trailing space (!)", RequiresNetwork) {
+    runSearch(Search.MajorBody("charon")) shouldEqual List(
+      Resolution(EK.MajorBody(901), "Charon")
+    ).asRight
+  }
+
+  test("major body search should handle single result without trailing space", RequiresNetwork) {
+    runSearch(Search.MajorBody("europa")) shouldEqual List(
+      Resolution(EK.MajorBody(502), "Europa")
+    ).asRight
+  }
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsNameQuerySpec.scala
@@ -92,7 +92,7 @@ final class HorizonsNameQuerySpec extends CatsSuite with RespectIncludeTags {
     runSearch(Search.MajorBody("covfefe")) shouldEqual Nil.asRight
   }
 
-  ignore("major body search should handle empty results with small-body fallthrough (many)", RequiresNetwork) {
+  test("major body search should handle empty results with small-body fallthrough (many)", RequiresNetwork) {
     runSearch(Search.MajorBody("hu")) shouldEqual Nil.asRight
   }
 

--- a/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/HorizonsSolutionRefQuerySpec.scala
@@ -1,0 +1,130 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+
+import gem.{ EphemerisKey, HorizonsSolutionRef }
+
+import gem.test.RespectIncludeTags
+import gem.test.Tags.RequiresNetwork
+
+import cats.tests.CatsSuite
+
+final class HorizonsSolutionRefQuerySpec extends CatsSuite with RespectIncludeTags {
+
+  import HorizonsSolutionRefQuerySpec._
+
+  test("parse solution ref terminated by comma") {
+    HorizonsSolutionRefQuery.parseSolutionRef(wild2, wild2Header) shouldEqual Some(HorizonsSolutionRef("JPL#K162/5"))
+  }
+
+  test("parse solution ref terminated by newline") {
+    HorizonsSolutionRefQuery.parseSolutionRef(beer, beerHeader) shouldEqual Some(HorizonsSolutionRef("JPL#23"))
+  }
+
+  test("parse a major body without solution ref") {
+    HorizonsSolutionRefQuery.parseSolutionRef(titan, titanHeader) shouldEqual Some(HorizonsSolutionRef("JUn 17, 2016"))
+  }
+
+  test("runs comet solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(wild2).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+
+  test("runs asteroid solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(beer).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+
+  test("runs major body solution ref query", RequiresNetwork) {
+    HorizonsSolutionRefQuery(titan).lookup.unsafeRunSync.isDefined shouldBe true
+  }
+}
+
+object HorizonsSolutionRefQuerySpec {
+
+  val wild2: EphemerisKey.Horizons =
+    EphemerisKey.Comet("81P")
+
+  val wild2Header: String =
+    """
+      |*******************************************************************************
+      |JPL/HORIZONS                     81P/Wild 2                2017-Sep-27 12:26:51
+      |Rec #:900817 (+COV)   Soln.date: 2017-Jul-06_14:39:31   # obs: 4021 (2008-2017)
+      |
+      |IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+      |
+      |  EPOCH=  2455772.5 ! 2011-Jul-30.0000000 (TDB)    RMSW= n.a.
+      |   EC= .5370816286507473   QR= 1.597991694337067   TP= 2455250.0788030997
+      |   OM= 136.0976955732219   W= 41.75965127535293    IN= 3.237207856138221
+      |   A= 3.451994548584135    MA= 80.282282601105     ADIST= 5.305997402831204
+      |   PER= 6.4137697671158    N= .153673474           ANGMOM= .026959831
+      |   DAN= 1.75367            DDN= 4.09807            L= 177.8118934
+      |   B= 2.1553656            MOID= .60296798         TP= 2010-Feb-22.5788030997
+      |
+      |Comet physical (GM= km^3/s^2; RAD= km):
+      |   GM= n.a.                RAD= 2.
+      |   M1=  8.8      M2=  13.1     k1=  14.    k2=  5.      PHCOF=  .030
+      |
+      |Comet non-gravitational force model (AMRAT=m^2/kg;A1-A3=au/d^2;DT=days;R0=au):
+      |   AMRAT=  0.                                      DT=  0.
+      |   A1= 1.811725646257E-9   A2= 3.974820487201E-11  A3= 0.
+      | Standard model:
+      |   ALN=  .1112620426   NK=  4.6142   NM=  2.15     NN=  5.093    R0=  2.808
+      |
+      |COMET comments
+      |1: soln ref.= JPL#K162/5, data arc: 2008-10-20 to 2017-06-24
+      |2: k1=14., k2=5., phase coef.=0.03;
+      |*******************************************************************************
+    """.stripMargin
+
+  val beer: EphemerisKey.Horizons =
+    EphemerisKey.AsteroidNew("1971 UC1")
+
+  val beerHeader: String =
+    """
+      |*******************************************************************************
+      |JPL/HORIZONS                1896 Beer (1971 UC1)           2017-Sep-27 13:57:35
+      |Rec #:  1896 (+COV)   Soln.date: 2017-May-15_14:17:06   # obs: 1566 (1949-2017)
+      |
+      |IAU76/J2000 helio. ecliptic osc. elements (au, days, deg., period=Julian yrs):
+      |
+      |  EPOCH=  2455763.5 ! 2011-Jul-21.00 (TDB)         Residual RMS= .33782
+      |   EC= .2217996492354765   QR= 1.842496797109042   TP= 2455815.8047106094
+      |   OM= 182.1795820773458   W=  180.1210417236072   IN= 2.220651628945542
+      |   A= 2.367638096409141    MA= 345.8494963260648   ADIST= 2.892779395709239
+      |   PER= 3.64318            N= .270539749           ANGMOM= .02580981
+      |   DAN= 2.89278            DDN= 1.8425             L= 2.3005429
+      |   B= -.0046903            MOID= .83910203         TP= 2011-Sep-11.3047106094
+      |
+      |Asteroid physical parameters (km, seconds, rotational period in hours):
+      |   GM= n.a.                RAD= 2.6885             ROTPER= 3.3278
+      |   H= 13.8                 G= .150                 B-V= n.a.
+      |                           ALBEDO= .202            STYP= n.a.
+      |
+      |ASTEROID comments:
+      |1: soln ref.= JPL#23
+      |2: source=ORB
+      |*******************************************************************************
+    """.stripMargin
+
+  val titan: EphemerisKey.Horizons =
+    EphemerisKey.MajorBody(606)
+
+  val titanHeader: String =
+    """
+      |*******************************************************************************
+      | Revised: JUn 17, 2016              Titan / (Saturn)                        606
+      |                         http://ssd.jpl.nasa.gov/?sat_phys_par
+      |                           http://ssd.jpl.nasa.gov/?sat_elem
+      |
+      | SATELLITE PHYSICAL PROPERTIES:
+      |  Mean Radius (km)       = 2575.5   +-  2.0  Density (g/cm^3) =  1.880 +- 0.004
+      |  Mass (10^19 kg)        = 13455.3           Geometric Albedo =  0.2
+      |  GM (km^3/s^2)          = 8978.13  +-  0.06  V(1,0)          = -1.2
+      |
+      | SATELLITE ORBITAL DATA:
+      |  Semi-major axis, a (km)= 1221.87 (10^3)  Orbital period     = 15.945421 d
+      |  Eccentricity, e        = 0.0288          Rotational period  =
+      |  Inclination, i  (deg)  = 0.28
+      |*******************************************************************************
+    """.stripMargin
+}

--- a/modules/ephemeris/src/test/scala/gem/horizons/tcs/TcsFormatSpec.scala
+++ b/modules/ephemeris/src/test/scala/gem/horizons/tcs/TcsFormatSpec.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.horizons
+package tcs
+
+import cats.tests.CatsSuite
+
+
+final class TcsFormatSpec extends CatsSuite with EphemerisTestSupport {
+
+  private val Eph = eph(
+    "2018-Jan-08 09:43:00.000" -> (("15 02 51.4497 -16 08 04.858",  "26.51632", "-8.34743")),
+    "2018-Jan-08 09:44:00.000" -> (("01 30 59.1212  08 54 25.405",   "0.76957",  "0.35575")),
+    "2018-Jan-08 09:45:00.000" -> (("22 59 58.5440 -16 25 54.600", "-57.80276", "29.71677"))
+  )
+
+  private val Str = List(
+    " 2018-Jan-08 09:43 2458126.904861111     15 02 51.4497 -16 08 04.858  26.51632  -8.34743",
+    " 2018-Jan-08 09:44 2458126.905555556     01 30 59.1212  08 54 25.405   0.76957   0.35575",
+    " 2018-Jan-08 09:45 2458126.906250000     22 59 58.5440 -16 25 54.600 -57.80276  29.71677"
+  )
+
+  test("formatting elements") {
+    Eph.toList.zip(Str).foreach { case (e, s) =>
+      assert(TcsFormat.formatElement(e) == s)
+    }
+  }
+}

--- a/modules/gen/src/main/scala/gem/sql/EnumDef.scala
+++ b/modules/gen/src/main/scala/gem/sql/EnumDef.scala
@@ -25,6 +25,7 @@ object EnumDef {
     implicit def caseBoolean[S] = at[(S, Boolean)] { _ => Option.empty[String] }
     implicit def caseDouble[S] = at[(S, Double)] { _ => Option.empty[String] }
     implicit def caseBigDecimal[S] = at[(S, BigDecimal)] { _ => Option.empty[String] }
+    implicit def caseOptionBigDecimal[S] = at[(S, Option[BigDecimal])] { _ => Option.empty[String] }
     implicit def caseArcseconds[S] = at[(S, Arcseconds)] { _ =>  Some("gsp.math.Angle") }
     implicit def caseDegrees[S] = at[(S, Degrees)] { _ =>  Some("gsp.math.Angle") }
     implicit def caseZoneId[S] = at[(S, ZoneId)] { _ =>  Some("java.time.ZoneId") }
@@ -57,6 +58,7 @@ object EnumDef {
     implicit def caseBoolean [S <: Symbol] = at[(S, Boolean) ] { case (s, _) => "  val " + s.name + ": Boolean" }
     implicit def caseDouble  [S <: Symbol] = at[(S, Double)  ] { case (s, _) => "  val " + s.name + ": Double" }
     implicit def caseBigDecimal  [S <: Symbol] = at[(S, BigDecimal)  ] { case (s, _) => "  val " + s.name + ": BigDecimal" }
+    implicit def caseOptionBigDecimal  [S <: Symbol] = at[(S, Option[BigDecimal])  ] { case (s, _) => "  val " + s.name + ": Option[BigDecimal]" }
     implicit def caseArcseconds [S <: Symbol] = at[(S, Arcseconds) ] { case (s, _) => "  val " + s.name + ": Angle"}
     implicit def caseDegrees [S <: Symbol] = at[(S, Degrees) ] { case (s, _) => "  val " + s.name + ": Angle"}
     implicit def caseZoneId  [S <: Symbol] = at[(S, ZoneId)  ] { case (s, _) => "  val " + s.name + ": ZoneId"}
@@ -95,6 +97,7 @@ object EnumDef {
     implicit val caseBoolean      = at[Boolean    ](a => a.toString)
     implicit val caseDouble       = at[Double     ](a => a.toString)
     implicit val caseBigDecimal   = at[BigDecimal ](a => a.toString)
+    implicit val caseOptionBigDecimal = at[Option[BigDecimal] ](a => a.fold("Option.empty[BigDecimal]")(aʹ => s"Some(${aʹ.toString})"))
     implicit val caseArcseconds   = at[Arcseconds ](a => s"Angle.fromDoubleArcseconds(${a.toArcsecs})")
     implicit val caseDegrees      = at[Degrees    ](a => s"Angle.fromDoubleDegrees(${a.toDegrees})")
     implicit val caseZoneId       = at[ZoneId     ](a => s"""ZoneId.of("${a.toString}")""")

--- a/modules/gen/src/main/scala/gem/sql/enum/MiscEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/MiscEnums.scala
@@ -106,8 +106,8 @@ object MiscEnums {
         val (a, b) = (Witness('Instrument), Witness('GiapiType))
         type A = a.T
         type B = b.T
-        type R = Record.`'tag -> String, 'instrument -> EnumRef[A], 'statusType -> EnumRef[B], 'statusItem -> String, 'applyItem -> String`.T
-        val ret = sql"SELECT concat(instrument_id, id), concat(instrument_id, id) tag, instrument_id, type, status_item, apply_item FROM e_giapi_status_apply".query[(String, R)]
+        type R = Record.`'tag -> String, 'instrument -> EnumRef[A], 'statusType -> EnumRef[B], 'statusItem -> String, 'applyItem -> String, 'tolerance -> Option[BigDecimal]`.T
+        val ret = sql"SELECT concat(instrument_id, id), concat(instrument_id, id) tag, instrument_id, type, status_item, apply_item, tolerance FROM e_giapi_status_apply".query[(String, R)]
         (ret, a.value: A, b.value: B)._1 // suppress unused warnigs
       },
 

--- a/modules/model/jvm/src/main/scala/gem/syntax/Stream.scala
+++ b/modules/model/jvm/src/main/scala/gem/syntax/Stream.scala
@@ -37,11 +37,11 @@ final class StreamOps[F[_], O](val self: Stream[F, O]) {
     */
   def filterOnFold[A](z: A)(f: (A, O) => A, p: A => Boolean): Stream[F, O] = {
 
-    def go(a: A, s: Stream[F,O]): Pull[F,O,Option[Unit]] =
+    def go(a: A, s: Stream[F,O]): Pull[F,O,Unit] =
 
       s.pull.uncons.flatMap {
         case None           =>
-          Pull.pure(None)
+          Pull.pure(())
 
         case Some((hd: Chunk[O], tl: Stream[F, O])) =>
           hd.foldLeft((Vector.empty[O], a)) { case ((matching, a), o) =>

--- a/modules/model/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
+++ b/modules/model/shared/src/main/scala/gem/enum/GiapiStatusApply.scala
@@ -17,47 +17,48 @@ sealed abstract class GiapiStatusApply(
   val instrument: Instrument,
   val statusType: GiapiType,
   val statusItem: String,
-  val applyItem: String
+  val applyItem: String,
+  val tolerance: Option[BigDecimal]
 ) extends Product with Serializable
 
 object GiapiStatusApply {
 
-  /** @group Constructors */ case object GpiAdc extends GiapiStatusApply("GpiAdc", Instrument.Gpi, GiapiType.Int, "gpi:adcDeploy", "gpi:selectAdc.deploy")
-  /** @group Constructors */ case object GpiUseAo extends GiapiStatusApply("GpiUseAo", Instrument.Gpi, GiapiType.Int, "gpi:ao:useAo", "gpi:configAo.useAo")
-  /** @group Constructors */ case object GpiAoOptimize extends GiapiStatusApply("GpiAoOptimize", Instrument.Gpi, GiapiType.Int, "gpi:ao:optimization", "gpi:configAo.optimize")
-  /** @group Constructors */ case object GpiUseCal extends GiapiStatusApply("GpiUseCal", Instrument.Gpi, GiapiType.Int, "gpi:cal:useCal", "gpi:configCal.useCal")
-  /** @group Constructors */ case object GpiFpmPinholeBias extends GiapiStatusApply("GpiFpmPinholeBias", Instrument.Gpi, GiapiType.Int, "gpi:cal:fpmPinholeBias", "gpi:configCal.fpmPinholeBias")
-  /** @group Constructors */ case object GpiIntegrationTime extends GiapiStatusApply("GpiIntegrationTime", Instrument.Gpi, GiapiType.Float, "gpi:currentIntegrationTime", "gpi:configIfs.integrationTime")
-  /** @group Constructors */ case object GpiNumCoadds extends GiapiStatusApply("GpiNumCoadds", Instrument.Gpi, GiapiType.Int, "gpi:currentNumCoadds", "gpi:configIfs.numCoadds")
-  /** @group Constructors */ case object GpiMagI extends GiapiStatusApply("GpiMagI", Instrument.Gpi, GiapiType.Float, "gpi:starIntensity", "gpi:configAo.magnitudeI")
-  /** @group Constructors */ case object GpiMagH extends GiapiStatusApply("GpiMagH", Instrument.Gpi, GiapiType.Float, "gpi:cal:magH", "gpi:configCal.magnitudeH")
-  /** @group Constructors */ case object GpiCalEntranceShutter extends GiapiStatusApply("GpiCalEntranceShutter", Instrument.Gpi, GiapiType.Int, "gpi:calEntranceShutter", "gpi:selectShutter.calEntranceShutter")
-  /** @group Constructors */ case object GpiCalReferenceShutter extends GiapiStatusApply("GpiCalReferenceShutter", Instrument.Gpi, GiapiType.Int, "gpi:referenceShutter", "gpi:selectShutter.calReferenceShutter")
-  /** @group Constructors */ case object GpiCalScienceShutter extends GiapiStatusApply("GpiCalScienceShutter", Instrument.Gpi, GiapiType.Int, "gpi:scienceShutter", "gpi:selectShutter.calScienceShutter")
-  /** @group Constructors */ case object GpiEntranceShutter extends GiapiStatusApply("GpiEntranceShutter", Instrument.Gpi, GiapiType.Int, "gpi:omssEntranceShutter", "gpi:selectShutter.entranceShutter")
-  /** @group Constructors */ case object GpiCalExitShutter extends GiapiStatusApply("GpiCalExitShutter", Instrument.Gpi, GiapiType.Int, "gpi:calExitShutter", "gpi:selectShutter.calExitShutter")
-  /** @group Constructors */ case object GpiPupilCamera extends GiapiStatusApply("GpiPupilCamera", Instrument.Gpi, GiapiType.Int, "gpi:pupilViewingMirror", "gpi:selectPupilCamera.deploy")
-  /** @group Constructors */ case object GpiSCPower extends GiapiStatusApply("GpiSCPower", Instrument.Gpi, GiapiType.Float, "gpi:artificialSourceSCpower", "gpi:selectSource.sourceSCpower")
-  /** @group Constructors */ case object GpiSCAttenuation extends GiapiStatusApply("GpiSCAttenuation", Instrument.Gpi, GiapiType.Float, "gpi:artificialSourceSCDb", "gpi:selectSource.sourceSCatten")
-  /** @group Constructors */ case object GpiSrcVis extends GiapiStatusApply("GpiSrcVis", Instrument.Gpi, GiapiType.Int, "gpi:artificialSourceVIS", "gpi:selectSource.sourceVis")
-  /** @group Constructors */ case object GpiSrcIR extends GiapiStatusApply("GpiSrcIR", Instrument.Gpi, GiapiType.Int, "gpi:artificialSourceIR", "gpi:selectSource.sourceIr")
-  /** @group Constructors */ case object GpiPolarizerDeplay extends GiapiStatusApply("GpiPolarizerDeplay", Instrument.Gpi, GiapiType.Int, "gpi:polarModulatorDeploy", "gpi:configPolarizer.deploy")
-  /** @group Constructors */ case object GpiPolarizerAngle extends GiapiStatusApply("GpiPolarizerAngle", Instrument.Gpi, GiapiType.Float, "gpi:polarizerAngle", "gpi:configPolarizer.angle")
-  /** @group Constructors */ case object GpiObservationMode extends GiapiStatusApply("GpiObservationMode", Instrument.Gpi, GiapiType.String, "gpi:observationMode", "gpi:observationMode.mode")
-  /** @group Constructors */ case object GpiIFSFilter extends GiapiStatusApply("GpiIFSFilter", Instrument.Gpi, GiapiType.String, "gpi:ifsFilter", "gpi:ifs:selectIfsFilter.maskStr")
-  /** @group Constructors */ case object GpiPPM extends GiapiStatusApply("GpiPPM", Instrument.Gpi, GiapiType.String, "gpi:ppmMask", "gpi:selectPupilPlaneMask.maskStr")
-  /** @group Constructors */ case object GpiFPM extends GiapiStatusApply("GpiFPM", Instrument.Gpi, GiapiType.String, "gpi:fpmMask", "gpi:selectFocalPlaneMask.maskStr")
-  /** @group Constructors */ case object GpiLyot extends GiapiStatusApply("GpiLyot", Instrument.Gpi, GiapiType.String, "gpi:lyotMask", "gpi:selectLyotMask.maskStr")
-  /** @group Constructors */ case object GpiAlignAndCalib extends GiapiStatusApply("GpiAlignAndCalib", Instrument.Gpi, GiapiType.Int, "gpi:alignAndCalib.part1", "gpi:alignAndCalib.part1")
-  /** @group Constructors */ case object GpiIFSReadMode extends GiapiStatusApply("GpiIFSReadMode", Instrument.Gpi, GiapiType.Int, "gpi:currentReadMode", "gpi:configIfs.readoutMode")
-  /** @group Constructors */ case object GpiIFSStartX extends GiapiStatusApply("GpiIFSStartX", Instrument.Gpi, GiapiType.Int, "gpi:currentStartX", "gpi:gpi:configIfs.startx")
-  /** @group Constructors */ case object GpiIFSStartY extends GiapiStatusApply("GpiIFSStartY", Instrument.Gpi, GiapiType.Int, "gpi:currentStartY", "gpi:gpi:configIfs.starty")
-  /** @group Constructors */ case object GpiIFSEndX extends GiapiStatusApply("GpiIFSEndX", Instrument.Gpi, GiapiType.Int, "gpi:currentEndX", "gpi:gpi:configIfs.endx")
-  /** @group Constructors */ case object GpiIFSEndY extends GiapiStatusApply("GpiIFSEndY", Instrument.Gpi, GiapiType.Int, "gpi:currentEndY", "gpi:gpi:configIfs.endy")
+  /** @group Constructors */ case object GpiAdc extends GiapiStatusApply("GpiAdc", Instrument.Gpi, GiapiType.Int, "gpi:adcDeploy", "gpi:selectAdc.deploy", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiUseAo extends GiapiStatusApply("GpiUseAo", Instrument.Gpi, GiapiType.Int, "gpi:ao:useAo", "gpi:configAo.useAo", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiAoOptimize extends GiapiStatusApply("GpiAoOptimize", Instrument.Gpi, GiapiType.Int, "gpi:ao:optimization", "gpi:configAo.optimize", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiUseCal extends GiapiStatusApply("GpiUseCal", Instrument.Gpi, GiapiType.Int, "gpi:cal:useCal", "gpi:configCal.useCal", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiFpmPinholeBias extends GiapiStatusApply("GpiFpmPinholeBias", Instrument.Gpi, GiapiType.Int, "gpi:cal:fpmPinholeBias", "gpi:configCal.fpmPinholeBias", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIntegrationTime extends GiapiStatusApply("GpiIntegrationTime", Instrument.Gpi, GiapiType.Float, "gpi:currentIntegrationTime", "gpi:configIfs.integrationTime", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiNumCoadds extends GiapiStatusApply("GpiNumCoadds", Instrument.Gpi, GiapiType.Int, "gpi:currentNumCoadds", "gpi:configIfs.numCoadds", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiMagI extends GiapiStatusApply("GpiMagI", Instrument.Gpi, GiapiType.Float, "gpi:starIntensity", "gpi:configAo.magnitudeI", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiMagH extends GiapiStatusApply("GpiMagH", Instrument.Gpi, GiapiType.Float, "gpi:cal:magH", "gpi:configCal.magnitudeH", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiCalEntranceShutter extends GiapiStatusApply("GpiCalEntranceShutter", Instrument.Gpi, GiapiType.Int, "gpi:calEntranceShutter", "gpi:selectShutter.calEntranceShutter", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiCalReferenceShutter extends GiapiStatusApply("GpiCalReferenceShutter", Instrument.Gpi, GiapiType.Int, "gpi:referenceShutter", "gpi:selectShutter.calReferenceShutter", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiCalScienceShutter extends GiapiStatusApply("GpiCalScienceShutter", Instrument.Gpi, GiapiType.Int, "gpi:scienceShutter", "gpi:selectShutter.calScienceShutter", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiEntranceShutter extends GiapiStatusApply("GpiEntranceShutter", Instrument.Gpi, GiapiType.Int, "gpi:omssEntranceShutter", "gpi:selectShutter.entranceShutter", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiCalExitShutter extends GiapiStatusApply("GpiCalExitShutter", Instrument.Gpi, GiapiType.Int, "gpi:calExitShutter", "gpi:selectShutter.calExitShutter", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiPupilCamera extends GiapiStatusApply("GpiPupilCamera", Instrument.Gpi, GiapiType.Int, "gpi:pupilViewingMirror", "gpi:selectPupilCamera.deploy", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiSCPower extends GiapiStatusApply("GpiSCPower", Instrument.Gpi, GiapiType.Float, "gpi:artificialSourceSCpower", "gpi:selectSource.sourceSCpower", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiSCAttenuation extends GiapiStatusApply("GpiSCAttenuation", Instrument.Gpi, GiapiType.Float, "gpi:artificialSourceSCDb", "gpi:selectSource.sourceSCatten", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiSrcVis extends GiapiStatusApply("GpiSrcVis", Instrument.Gpi, GiapiType.Int, "gpi:artificialSourceVIS", "gpi:selectSource.sourceVis", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiSrcIR extends GiapiStatusApply("GpiSrcIR", Instrument.Gpi, GiapiType.Int, "gpi:artificialSourceIR", "gpi:selectSource.sourceIr", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiPolarizerDeplay extends GiapiStatusApply("GpiPolarizerDeplay", Instrument.Gpi, GiapiType.Int, "gpi:polarModulatorDeploy", "gpi:configPolarizer.deploy", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiObservationMode extends GiapiStatusApply("GpiObservationMode", Instrument.Gpi, GiapiType.String, "gpi:observationMode", "gpi:observationMode.mode", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIFSFilter extends GiapiStatusApply("GpiIFSFilter", Instrument.Gpi, GiapiType.String, "gpi:ifsFilter", "gpi:ifs:selectIfsFilter.maskStr", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiPPM extends GiapiStatusApply("GpiPPM", Instrument.Gpi, GiapiType.String, "gpi:ppmMask", "gpi:selectPupilPlaneMask.maskStr", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiFPM extends GiapiStatusApply("GpiFPM", Instrument.Gpi, GiapiType.String, "gpi:fpmMask", "gpi:selectFocalPlaneMask.maskStr", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiLyot extends GiapiStatusApply("GpiLyot", Instrument.Gpi, GiapiType.String, "gpi:lyotMask", "gpi:selectLyotMask.maskStr", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiAlignAndCalib extends GiapiStatusApply("GpiAlignAndCalib", Instrument.Gpi, GiapiType.Int, "gpi:alignAndCalib.part1", "gpi:alignAndCalib.part1", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIFSReadMode extends GiapiStatusApply("GpiIFSReadMode", Instrument.Gpi, GiapiType.Int, "gpi:currentReadMode", "gpi:configIfs.readoutMode", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIFSStartX extends GiapiStatusApply("GpiIFSStartX", Instrument.Gpi, GiapiType.Int, "gpi:currentStartX", "gpi:gpi:configIfs.startx", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIFSStartY extends GiapiStatusApply("GpiIFSStartY", Instrument.Gpi, GiapiType.Int, "gpi:currentStartY", "gpi:gpi:configIfs.starty", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIFSEndX extends GiapiStatusApply("GpiIFSEndX", Instrument.Gpi, GiapiType.Int, "gpi:currentEndX", "gpi:gpi:configIfs.endx", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiIFSEndY extends GiapiStatusApply("GpiIFSEndY", Instrument.Gpi, GiapiType.Int, "gpi:currentEndY", "gpi:gpi:configIfs.endy", Option.empty[BigDecimal])
+  /** @group Constructors */ case object GpiPolarizerAngle extends GiapiStatusApply("GpiPolarizerAngle", Instrument.Gpi, GiapiType.Float, "gpi:polarizerAngle", "gpi:configPolarizer.angle", Some(1.0000))
 
   /** All members of GiapiStatusApply, in canonical order. */
   val all: List[GiapiStatusApply] =
-    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiPolarizerAngle, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib, GpiIFSReadMode, GpiIFSStartX, GpiIFSStartY, GpiIFSEndX, GpiIFSEndY)
+    List(GpiAdc, GpiUseAo, GpiAoOptimize, GpiUseCal, GpiFpmPinholeBias, GpiIntegrationTime, GpiNumCoadds, GpiMagI, GpiMagH, GpiCalEntranceShutter, GpiCalReferenceShutter, GpiCalScienceShutter, GpiEntranceShutter, GpiCalExitShutter, GpiPupilCamera, GpiSCPower, GpiSCAttenuation, GpiSrcVis, GpiSrcIR, GpiPolarizerDeplay, GpiObservationMode, GpiIFSFilter, GpiPPM, GpiFPM, GpiLyot, GpiAlignAndCalib, GpiIFSReadMode, GpiIFSStartX, GpiIFSStartY, GpiIFSEndX, GpiIFSEndY, GpiPolarizerAngle)
 
   /** Select the member of GiapiStatusApply with the given tag, if any. */
   def fromTag(s: String): Option[GiapiStatusApply] =

--- a/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Decoders.scala
@@ -1,0 +1,230 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import cats.implicits._
+import gem.{ Dataset, EphemerisKey, Observation, Program, Step, Target }
+import gem.config._
+import gem.enum._
+import gem.ocs2.pio.PioPath._
+import gem.ocs2.pio.{ PioDecoder, PioError, PioPath }
+import gem.ocs2.pio.PioError.ParseError
+import gem.ocs2.pio.PioDecoder.fromParse
+import gsp.math._
+import gsp.math.syntax.all._
+
+import java.time.Instant
+
+import scala.collection.immutable.{ TreeMap, TreeSet }
+import scala.xml.Node
+
+
+/** `PioDecoder` instances for our model types.
+  */
+object Decoders {
+
+  implicit val MagnitudeSystemDecoder: PioDecoder[MagnitudeSystem] =
+    fromParse { Parsers.magnitudeSystem }
+
+  implicit val MagnitudeBandDecoder: PioDecoder[MagnitudeBand] =
+    fromParse { Parsers.magnitudeBand }
+
+  implicit val RightAscensionDecoder: PioDecoder[RightAscension] =
+    fromParse { Parsers.ra }
+
+  implicit val DeclinationDecoder: PioDecoder[Declination] =
+    fromParse { Parsers.dec }
+
+  implicit val CoordinatesDecoder: PioDecoder[Coordinates] =
+    PioDecoder { n =>
+      for {
+        r <- (n \! "#ra" ).decode[RightAscension]
+        d <- (n \! "#dec").decode[Declination]
+      } yield Coordinates(r, d)
+    }
+
+  implicit val EpochDecoder: PioDecoder[Epoch] =
+    fromParse { Parsers.epoch }
+
+  implicit val ProperMotionDecoder: PioDecoder[ProperMotion] =
+    PioDecoder { n =>
+      for {
+        c  <- (n \! "&coordinates").decode[Coordinates]
+        e  <- (n \? "&proper-motion" \! "#epoch"    ).decodeOrElse[Epoch](Epoch.J2000)
+        dr <- (n \? "&proper-motion" \! "#delta-ra" ).decode[Double]
+        dd <- (n \? "&proper-motion" \! "#delta-dec").decode[Double]
+        pv  = dr.flatMap { r =>
+          dd.map { d =>
+            Offset(
+              Offset.P(Angle.fromMicroarcseconds((r * 1000).round)),
+              Offset.Q(Angle.fromMicroarcseconds((d * 1000).round))
+            )
+          }
+        }
+        dz <- (n \? "#redshift").decode[Double]
+        rv  = dz.map(RadialVelocity.unsafeFromRedshift)
+        dp <- (n \? "#parallax").decode[Double]
+        p   = dp.map(d => Angle.fromMicroarcseconds((d * 1000).round))
+      } yield ProperMotion(c, e, pv, rv, p)
+    }
+
+  implicit val EphemerisKeyTypeDecoder: PioDecoder[EphemerisKeyType] =
+    fromParse { Parsers.ephemerisKeyType }
+
+  implicit val EphemerisKeyDecoder: PioDecoder[EphemerisKey] = {
+      def fromDes(des: String, tag: EphemerisKeyType): Either[PioError, EphemerisKey] =
+        tag match {
+          case EphemerisKeyType.AsteroidNew  =>
+            Right(EphemerisKey.AsteroidNew(des))
+
+          case EphemerisKeyType.AsteroidOld  =>
+            des.parseIntOption.toRight(PioError.ParseError(des, "AsteroidOld")).map(EphemerisKey.AsteroidOld(_))
+
+          case EphemerisKeyType.Comet        =>
+            Right(EphemerisKey.Comet(des))
+
+          case EphemerisKeyType.MajorBody    =>
+            des.parseIntOption.toRight(PioError.ParseError(des, "MajorBody")).map(EphemerisKey.MajorBody(_))
+
+          case EphemerisKeyType.UserSupplied =>
+            Left(ParseError(des, "EphemerisKey"))
+        }
+
+      PioDecoder { n =>
+        for {
+          des <- (n \! "#des").decode[String]
+          tag <- (n \! "#tag").decode[EphemerisKeyType]
+          key <- fromDes(des, tag)
+        } yield key
+      }
+    }
+
+  implicit val TrackDecoder: PioDecoder[Either[EphemerisKey, ProperMotion]] =
+    PioDecoder { n =>
+      (n \! "#tag").decode[String].flatMap {
+        case "nonsidereal" => (n \! "&horizons-designation").decode[EphemerisKey].map(Left(_))
+        case "sidereal"    => PioDecoder[ProperMotion].decode(n).map(Right(_))
+        case tag           => Left(ParseError(tag, "Track"))
+      }
+    }
+
+
+  implicit val TargetDecoder: PioDecoder[Target] =
+    PioDecoder { n =>
+      for {
+        name  <- (n \! "#name").decode[String]
+        track <- PioDecoder[Either[EphemerisKey, ProperMotion]].decode(n)
+      } yield Target(name, track)
+    }
+
+  implicit val UserTargetTypeDecoder: PioDecoder[UserTargetType] =
+    fromParse { Parsers.userTargetType }
+
+  implicit val UserTargetDecoder: PioDecoder[UserTarget] =
+    PioDecoder { n =>
+      for {
+        t <- (n \! "&spTarget" \! "&target").decode[Target]
+        y <- (n \! "#type"                 ).decode[UserTargetType]
+      } yield UserTarget(t, y)
+    }
+
+  implicit val DatasetLabelDecoder: PioDecoder[Dataset.Label] =
+    fromParse { Parsers.datasetLabel }
+
+  implicit val ObservationIdDecoder: PioDecoder[Observation.Id] =
+    fromParse { Parsers.obsId }
+
+  implicit val ProgramIdDecoder: PioDecoder[Program.Id] =
+    fromParse { Parsers.progId }
+
+  implicit val InstrumentDecoder: PioDecoder[Instrument] =
+    fromParse { Parsers.instrument }
+
+  implicit val DatasetDecoder: PioDecoder[Dataset] =
+    PioDecoder { n =>
+      for {
+        l <- (n \! "#datasetLabel").decode[Dataset.Label]
+        f <- (n \! "#dhsFilename" ).decode[String]
+        t <- (n \! "#timestamp"   ).decode[Instant]
+      } yield Dataset(l, f, t)
+    }
+
+  // Decodes all the datasets in either a program or observation node.  We have
+  // to explicitly specify that we want the "dataset" elements within a
+  // "datasets" paramset because they are duplicated in the event data.
+  implicit val DatasetsDecoder: PioDecoder[List[Dataset]] =
+    PioDecoder { n =>
+      (n \\* "obsExecLog" \\* "&datasets" \\* "&dataset").decode[Dataset]
+    }
+
+  implicit val ObservationIndexDecoder: PioDecoder[Index] =
+    PioDecoder { n =>
+      (n \! "@name").decode[Observation.Id].map(_.index)
+    }
+
+  def targetEnvironmentDecoder(i: Instrument): PioDecoder[TargetEnvironment] = {
+    import gem.enum.TrackType
+
+    def trackType(targetNode: scala.xml.Node): Option[TrackType] =
+      (targetNode \? "#tag").decode[String].toOption.flatten.collect {
+        case "sidereal"    => TrackType.Sidereal: TrackType
+        case "nonsidereal" => TrackType.Nonsidereal: TrackType
+      }
+
+    // filter out "too" and empty non-sidereal (that is, w/o horizons id) for now
+    def validTargets(lst: PioPath.Listing)(f: Node => PioPath.Required): PioPath.Listing =
+      lst.copy(node = lst.node.map { ns =>
+        ns.filter { n =>
+
+          // We have to drill down to the target node for this filter and
+          // extract the track type
+          val ty = for {
+            t <- f(n).node.toOption // "target" node
+            y <- trackType(t)       // track type
+          } yield (t, y)
+
+          // Sidereal targets or non-sidereal with an horizons id are ok
+          ty.exists { case (t, y) =>
+            (y === TrackType.Sidereal) || (t \? "&horizons-designation").node.isDefined.getOrElse(false)
+          }
+        }
+      })
+
+    PioDecoder { n =>
+      for {
+        a <- validTargets(n \* "&asterism" \! "&target")(_.toRequired).decode[Target]
+        // g <- guideEnvironment
+        u <- validTargets(n \? "&userTargets" \* "&userTarget")(_ \! "&spTarget" \! "&target").decode[UserTarget]
+      } yield {
+        a.headOption.map(Asterism.unsafeFromSingleTarget(_, i)) match {
+          case None    => TargetEnvironment.fromInstrument(i, TreeSet.fromList(u))
+          case Some(a) => TargetEnvironment.fromAsterism(a, TreeSet.fromList(u))
+        }
+      }
+    }
+  }
+
+  implicit val ObservationDecoder: PioDecoder[Observation] =
+    PioDecoder { n =>
+      for {
+        t <- (n \! "data" \? "#title"                   ).decodeOrZero[String]
+        s <- (n \! "sequence"                           ).decode[StaticConfig](StaticDecoder)
+        d <- (n \! "sequence"                           ).decode[List[Step]](SequenceDecoder)
+        i  = Instrument.forStaticConfig(s) // stable identifier needed below
+        e <- (n \? "telescope" \! "data" \! "&targetEnv").decodeOrElse(TargetEnvironment.fromInstrument(i, TreeSet.empty))(targetEnvironmentDecoder(i))
+      } yield Observation.unsafeAssemble(t, e, s, d)
+    }
+
+  implicit val ProgramDecoder: PioDecoder[Program] =
+    PioDecoder { n =>
+      for {
+        id <- (n \!  "@name"           ).decode[Program.Id]
+        t  <- (n \!  "data" \? "#title").decodeOrZero[String]
+        is <- (n \\* "observation"     ).decode[Index]
+        os <- (n \\* "observation"     ).decode[Observation]
+      } yield Program(id, t, TreeMap.fromList(is.zip(os)))
+    }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/DoobieClient.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.effect.{ ContextShift, Effect, IO }
+import cats.implicits._
+import doobie._, doobie.implicits._
+import gem.dao.meta._
+import doobie.postgres.implicits._
+import java.util.logging.{ Level, Logger }
+import scala.concurrent.ExecutionContext
+
+/** Shared support for import applications using Doobie. */
+trait DoobieClient extends ProgramIdMeta with IndexMeta {
+
+  implicit val ioContextShift: ContextShift[IO] =
+    IO.contextShift(ExecutionContext.global)
+
+  def configureLogging[M[_]: Effect]: M[Unit] =
+    Effect[M].delay(
+      List("edu.gemini.spModel.type.SpTypeUtil")
+        .map(Logger.getLogger)
+        .foreach(_.setLevel(Level.OFF))
+    )
+
+  def ignoreUniqueViolation(fa: ConnectionIO[Int]): ConnectionIO[Int] =
+    for {
+      s <- HC.setSavepoint
+      n <- fa.onUniqueViolation(HC.rollback(s).as(0)) guarantee HC.releaseSavepoint(s)
+    } yield n
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/FileImporter.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.effect.IO, cats.implicits._
+import doobie._, doobie.implicits._
+import gem.{ Dataset, Log, Program, User }
+import gem.dao.{ DatabaseConfiguration, UserDao }
+import gem.ocs2.Decoders._
+import gem.ocs2.pio.PioDecoder
+import java.io.File
+import org.flywaydb.core.Flyway
+import scala.xml.{XML, Elem}
+
+
+/** Imports OCS2 program files exported to the same format sent by the
+  * Ocs3ExportServlet at http://g[ns]odb:8442/ocs3/fetch/programId or
+  * by using the OSGi shell command "exportOcs3" from the ODB shell.
+  */
+object FileImporter extends DoobieClient {
+
+  private val conf = DatabaseConfiguration.forTesting
+  private val xa   = conf.transactor[IO]
+
+  val dir: File = new File("archive")
+
+  val checkArchive: IO[Unit] =
+    IO(dir.isDirectory).flatMap { b =>
+      IO(if (b) () else sys.error("""
+        |
+        |** Root of project needs an archive/ dir with program xml files in it.
+        |** Try ln -s /path/to/some/stuff archive
+        |""".stripMargin))
+    }
+
+  val clean: IO[Int] =
+    IO {
+      val flyway = Flyway.configure.dataSource(conf.connectUrl, conf.userName, conf.password).load
+      flyway.clean()
+      flyway.migrate()
+    }
+
+  def read(f: File): IO[Elem] =
+    IO(XML.loadFile(f))
+
+  def readAndInsert(u: User[_], f: File, log: Log[ConnectionIO]): IO[Unit] =
+    read(f).flatMap { elem =>
+      PioDecoder[(Program, List[Dataset])].decode(elem) match {
+        case Left(err)      => sys.error(s"Problem parsing ${f.getName}: $err")
+        case Right((p, ds)) => log.log(u, s"insert ${p.id}")(Importer.importProgram(p, ds)).transact(xa)
+      }
+    }.handleErrorWith(e => IO(e.printStackTrace))
+
+  def xmlFiles(num: Int): IO[List[File]] =
+    IO(dir.listFiles.toList.filter(_.getName.toLowerCase.endsWith(".xml"))).map(_.take(num))
+
+  def readAndInsertAll(u: User[_], num: Int, log: Log[ConnectionIO]): IO[Unit] =
+    xmlFiles(num).flatMap(_.traverse_(readAndInsert(u, _, log)))
+
+  def runl(args: List[String]): IO[Unit] =
+    for {
+      u <- UserDao.selectRootUser.transact(xa)
+      l <- Log.newLog[ConnectionIO]("importer", xa).transact(xa)
+      n <- IO(args.headOption.map(_.toInt).getOrElse(Int.MaxValue))
+      _ <- checkArchive
+      _ <- configureLogging[IO]
+      _ <- clean
+      _ <- readAndInsertAll(u, n, l)
+      _ <- l.shutdown(5 * 1000).transact(xa) // if we're not done soon something is wrong
+      _ <- IO(Console.println("Done.")) // scalastyle:off console.io
+    } yield ()
+
+  def main(args: Array[String]): Unit =
+    runl(args.toList).unsafeRunSync
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/ImportServer.scala
@@ -1,0 +1,96 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import cats.effect.{ ContextShift, IO, IOApp, ExitCode }
+import cats.implicits._
+import gem.dao.DatabaseConfiguration
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.Router
+import org.http4s.implicits._
+
+import java.util.logging.Logger
+
+/** A server that accepts HTTP requests to import observations or programs from
+  * an OCS2 ODB.  If the corresponding observation or program has already been
+  * loaded, it is deleted and wholly replaced by the latest version from the
+  * ODB.
+  */
+final class ImportServer(ocsHost: String)(implicit ev: ContextShift[IO]) {
+
+  private val xa = DatabaseConfiguration.forTesting.transactor[IO]
+
+  private def badRequest(id: String, idType: String): IO[Response[IO]] =
+    BadRequest(s"Could not parse $idType id '$id'")
+
+  private def importRemote[A](
+    idStr:     String,
+    parseFun:  String => Option[A],
+    typeName:  String,
+    importFun: A => IO[Either[String, Unit]]
+  ): IO[Response[IO]] =
+    parseFun(idStr).toRight(badRequest(idStr, typeName)).map { id =>
+      importFun(id).map {
+        case Left(msg) => InternalServerError(s"Error parsing $idStr: $msg")
+        case Right(_)  => Ok(s"Imported $idStr")
+      }.flatten
+    }.merge
+
+  def importObservation(obsIdStr: String): IO[Response[IO]] =
+    importRemote[Observation.Id](
+      obsIdStr,
+      Observation.Id.fromString,
+      "observation",
+      OdbClient.importObservation(ocsHost, _, xa)
+    )
+
+  def importProgram(pidStr: String): IO[Response[IO]] = {
+    importRemote[Program.Id](
+      pidStr,
+      ProgramId.fromString.getOption,
+      "program",
+      OdbClient.importProgram(ocsHost, _, xa)
+    )
+  }
+}
+
+object ImportServer extends IOApp {
+  private val Log = Logger.getLogger(ImportServer.getClass.getName)
+
+  // Port where our http service will run.
+  val port: Int = 8989
+
+  def run(args: List[String]): IO[ExitCode] = {
+
+    val hostName = args match {
+      case Nil       => "localhost"
+      case host :: _ => host
+    }
+
+    Log.info(s"Starting import server on port $port connecting to $hostName")
+
+    val importServer = new ImportServer(hostName)
+
+    val service = HttpRoutes.of[IO] {
+      case GET -> Root / "obs" / obsId =>
+        importServer.importObservation(obsId)
+
+      case GET -> Root / "prog" / progId =>
+        importServer.importProgram(progId)
+    }
+
+    val httpApp = Router[IO]("/import" -> service).orNotFound
+
+    BlazeServerBuilder[IO]
+      .bindHttp(8989, "localhost")
+      .withHttpApp(httpApp)
+      .resource.use(_ => IO.never)
+      .start
+      .as(ExitCode.Success)
+
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Importer.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import gem.dao._
+
+import cats.implicits._
+import doobie._, doobie.implicits._
+
+import scala.collection.immutable.TreeMap
+
+
+/** Support for writing programs and observations to the database.
+  */
+object Importer extends DoobieClient {
+
+  object datasets {
+    def lookupStepIds(oid: Observation.Id): ConnectionIO[List[Int]] =
+      sql"SELECT step_id FROM step WHERE program_id = ${oid.pid} AND observation_index = ${oid.index} ORDER BY location".query[Int].to[List]
+
+    def tuples(sids: List[Int], ds: List[Dataset]): List[(Int, Dataset)] = {
+      val sidMap = sids.zipWithIndex.map(_.swap).toMap
+      ds.flatMap { d => sidMap.get(d.label.index - 1).map(_ -> d).toList }
+    }
+
+    def write(oid: Observation.Id, ds: List[Dataset]): ConnectionIO[Unit] =
+      for {
+        sids <- lookupStepIds(oid)
+        _    <- tuples(sids, ds).traverse_ { case (sid, d) => DatasetDao.insert(sid, d) }
+      } yield ()
+  }
+
+  def importObservation(oid: Observation.Id, o: Observation, ds: List[Dataset]): ConnectionIO[Unit] = {
+
+    val rmObservation: ConnectionIO[Unit] =
+      sql"DELETE FROM observation WHERE program_id = ${oid.pid} AND observation_index = ${oid.index}".update.run.void
+
+    for {
+      _ <- ignoreUniqueViolation(ProgramDao.insertFlat(Program(oid.pid, "", TreeMap.empty)).as(1))
+      _ <- rmObservation
+      _ <- ObservationDao.insert(oid, o)
+      _ <- datasets.write(oid, ds)
+    } yield ()
+  }
+
+  def importProgram(p: Program, ds: List[Dataset]): ConnectionIO[Unit] = {
+
+    val rmProgram: ConnectionIO[Unit] =
+      sql"DELETE FROM program WHERE program_id = ${p.id}".update.run.void
+
+    val dsMap = ds.groupBy(_.label.observationId).withDefaultValue(List.empty[Dataset])
+
+    for {
+      _ <- rmProgram
+      _ <- ProgramDao.insert(p)
+      _ <- p.observations.toList.traverse_ { case (i, _) =>
+             val oid = Observation.Id(p.id, i)
+             datasets.write(oid, dsMap(oid))
+           }
+    } yield ()
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/Legacy.scala
@@ -1,0 +1,164 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+import gem.ocs2.pio.PioError._
+import gem.ocs2.pio.{PioError, PioOptional, PioParse}
+
+import scala.reflect.runtime.universe.TypeTag
+
+
+/** Legacy system (telescope, instrument, observe, calibration) key and parser
+  * definitions.
+  */
+object Legacy {
+  sealed abstract class System(val system: String) {
+
+    final class Key[A](val name: String, val parseString: PioParse[A])(implicit ev: TypeTag[A]) {
+
+      val path: String = s"$system:$name"
+
+      val tpe:  String = Key.clean(ev.tpe.toString)
+
+      def rawValue(cm: ConfigMap): Either[PioError, String] =
+        cm.get(path) toRight missingKey(name)
+
+      def parse(cm: ConfigMap): Either[PioError, A] =
+        rawValue(cm).flatMap { s => parseString(s) toRight parseError(s, tpe) }
+
+      def cparse(cm: ConfigMap): Either[PioError, Option[A]] =
+        parse(cm) match {
+          case Left(MissingKey(_)) => None.asRight
+          case Left(err)           => err.asLeft
+          case Right(a)            => Some(a).asRight
+        }
+
+      def cparseOrElse(cm: ConfigMap, a: => A): Either[PioError, A] =
+        cparse(cm).map { _.getOrElse(a) }
+
+      def oparse(cm: ConfigMap): PioOptional[A] =
+        PioOptional(cparse(cm))
+
+      override def toString: String =
+        s"Key[$tpe]($path)"
+
+    }
+
+    protected object Key {
+      // Clean up classnames in toString, which tells you the type of the key, which should be
+      // helpful for debugging.
+      private def clean(s: String) =
+        s.replace("edu.gemini.spModel.core.", "")
+         .replace("java.lang.", "")
+         .replace("java.time.", "")
+         .replace("gem.", "")
+
+      def apply[A: TypeTag](name: String)(parse: PioParse[A]): Key[A] =
+        new Key(name, parse)
+    }
+  }
+
+  case object Telescope extends System("telescope") {
+    val P = Key("p")(Parsers.offsetP)
+    val Q = Key("q")(Parsers.offsetQ)
+  }
+
+  case object Observe extends System("observe") {
+    val ObserveType  = Key("observeType" )(PioParse.string )
+    val ExposureTime = Key("exposureTime")(PioParse.seconds)
+  }
+
+  case object Ocs extends System("ocs") {
+    val ObservationId = Key("observationId")(Parsers.obsId)
+  }
+
+  case object Instrument extends System("instrument") {
+    val Instrument    = Key("instrument"   )(Parsers.instrument   )
+    val MosPreImaging = Key("mosPreimaging")(Parsers.mosPreImaging)
+
+    object Flamingos2 {
+      import Parsers.Flamingos2._
+      val Disperser   = Key("disperser"  )(disperser  )
+      val Filter      = Key("filter"     )(filter     )
+      val Fpu         = Key("fpu"        )(fpu        )
+      val LyotWheel   = Key("lyotWheel"  )(lyotWheel  )
+      val ReadMode    = Key("readMode"   )(readMode   )
+      val WindowCover = Key("windowCover")(windowCover)
+    }
+
+    object Gmos {
+      import Parsers.Gmos._
+      val Adc             = Key("adc"                    )(adc            )
+      val AmpCount        = Key("ampCount"               )(ampCount       )
+      val AmpGain         = Key("gainChoice"             )(ampGain        )
+      val AmpReadMode     = Key("ampReadMode"            )(ampReadMode    )
+      val CustomMaskMdf   = Key("fpuCustomMask"          )(PioParse.string)
+      val CustomSlitWidth = Key("customSlitWidth"        )(customSlitWidth)
+      val Detector        = Key("detectorManufacturer"   )(detector       )
+      val DisperserOrder  = Key("disperserOrder"         )(disperserOrder )
+      val DisperserLambda = Key("disperserLambda"        )(disperserLambda)
+      val Dtax            = Key("dtaXOffset"             )(dtax           )
+      val EOffsetting     = Key("useElectronicOffsetting")(nsEOffsetting  )
+      val NsBeamAp        = Key("nsBeamA-p"              )(Parsers.offsetP)
+      val NsBeamAq        = Key("nsBeamA-q"              )(Parsers.offsetQ)
+      val NsBeamBp        = Key("nsBeamB-p"              )(Parsers.offsetP)
+      val NsBeamBq        = Key("nsBeamB-q"              )(Parsers.offsetQ)
+      val NsCycles        = Key("nsNumCycles"            )(nsCycles       )
+      val NsShuffle       = Key("nsDetectorRows"         )(nsShuffle      )
+      val Roi             = Key("builtinROI"             )(roi            )
+      val XBinning        = Key("ccdXBinning"            )(xBinning       )
+      val YBinning        = Key("ccdYBinning"            )(yBinning       )
+
+      def roiKey(i: Int, n: String): Key[Short] =
+        Key(s"customROI$i$n")(PioParse.positiveShort)
+
+      def roiXMin(i: Int):   Key[Short] = roiKey(i, "Xmin"  )
+      def roiYMin(i: Int):   Key[Short] = roiKey(i, "Ymin"  )
+      def roiXRange(i: Int): Key[Short] = roiKey(i, "XRange")
+      def roiYRange(i: Int): Key[Short] = roiKey(i, "YRange")
+    }
+
+    object GmosNorth {
+      import Parsers.GmosNorth._
+      val Disperser       = Key("disperser")(disperser)
+      val Filter          = Key("filter"   )(filter   )
+      val Fpu             = Key("fpu"      )(fpu      )
+      val StageMode       = Key("stageMode")(stageMode)
+    }
+
+    object GmosSouth {
+      import Parsers.GmosSouth._
+      val Disperser       = Key("disperser")(disperser)
+      val Filter          = Key("filter"   )(filter   )
+      val Fpu             = Key("fpu"      )(fpu      )
+      val StageMode       = Key("stageMode")(stageMode)
+    }
+
+    object Gnirs {
+      import Parsers.Gnirs._
+      val AcquisitionMirror = Key("acquisitionMirror")(acquisitionMirror)
+      val Camera            = Key("camera"           )(camera)
+      val CoAdds            = Key("coadds"           )(Parsers.coadds)
+      val Decker            = Key("decker"           )(decker)
+      val Disperser         = Key("disperser"        )(disperser)
+      val Filter            = Key("filter"           )(filter)
+      val Fpu               = Key("slitWidth"        )(fpu)
+      val Prism             = Key("crossDispersed"   )(prism)
+      val ReadMode          = Key("readMode"         )(readMode)
+      val Wavelength        = Key("centralWavelength")(centralWavelength)
+      val WellDepth         = Key("wellDepth"        )(wellDepth)
+    }
+  }
+
+  object Calibration extends System("calibration") {
+    import Parsers.Calibration._
+    val Lamp         = Key("lamp"        )(lamp            )
+    val Filter       = Key("filter"      )(filter          )
+    val Diffuser     = Key("diffuser"    )(diffuser        )
+    val Shutter      = Key("shutter"     )(shutter         )
+    val ExposureTime = Key("exposureTime")(PioParse.seconds)
+    val CoAdds       = Key("coadds"      )(Parsers.coadds)
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/OdbClient.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/OdbClient.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package ocs2
+
+import gem.ocs2.Decoders._
+
+import gem.ocs2.pio.{ PioDecoder, PioError }
+import gem.ocs2.pio.PioError._
+
+import doobie._
+import doobie.implicits._
+import cats.effect._
+import cats.implicits._
+import org.http4s.client._
+import org.http4s.client.asynchttpclient.AsyncHttpClient
+import org.http4s.scalaxml.xml
+
+import java.net.URLEncoder
+
+import scala.xml.Elem
+
+
+/** ODB observation/program fetch client.
+  */
+object OdbClient {
+
+  /** Fetches an observation from an ODB. */
+  def fetchObservation[M[_]: ConcurrentEffect](
+    host: String,
+    id:   Observation.Id
+  ): M[Either[String, (Observation, List[Dataset])]] =
+    fetch[Observation, M](host, id.format)
+
+  /** Fetches a program from the ODB. */
+  def fetchProgram[M[_]: ConcurrentEffect](
+    host: String,
+    id:   Program.Id
+  ): M[Either[String, (Program, List[Dataset])]] =
+    fetch[Program, M](host, Program.Id.fromString.reverseGet(id))
+
+  /** Fetches an observation from the ODB and stores it in the database. */
+  def importObservation[M[_]: ConcurrentEffect](
+    host: String,
+    id:   Observation.Id,
+    xa:   Transactor[M]
+  ): M[Either[String, Unit]] =
+    fetchObservation(host, id).flatMap { _.traverse { case (o, ds) =>
+      Importer.importObservation(id, o, ds).transact(xa)
+    }}
+
+  /** Fetches a program from the ODB and stores it in the database. */
+  def importProgram[M[_]: ConcurrentEffect](
+    host: String,
+    id:   Program.Id,
+    xa:   Transactor[M]
+  ): M[Either[String, Unit]] =
+    fetchProgram(host, id).flatMap { _.traverse { case (p, ds) =>
+      Importer.importProgram(p, ds).transact(xa)
+    }}
+
+  private def fetchServiceUrl(host: String): String =
+    s"http://$host:8442/ocs3/fetch"
+
+  private def uri(host: String, id: String): String =
+    s"${fetchServiceUrl(host)}/${URLEncoder.encode(id, "UTF-8")}"
+
+  private def errorMessage(e: PioError): String =
+    e match {
+      case MissingKey(name)            => s"missing '$name'"
+      case ParseError(value, dataType) => s"could not parse '$value' as '$dataType'"
+    }
+
+  private def fetch[A: PioDecoder, M[_]: ConcurrentEffect](
+    host: String,
+    id:   String
+  ): M[Either[String, (A, List[Dataset])]] = {
+
+    val client: Resource[M, Client[M]] =
+      AsyncHttpClient.resource[M]()
+
+    client.use { c =>
+      c.expect[Elem](uri(host, id))
+        .map(PioDecoder[(A, List[Dataset])].decode(_).leftMap(errorMessage))
+        .attempt
+        .map(_.leftMap(ex => s"Problem fetching '$id': ${ex.getMessage}").flatten)
+    }
+
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SequenceDecoder.scala
@@ -1,0 +1,193 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+import gem._
+import gem.config._
+import gem.enum._
+import gem.ocs2.pio._
+import gsp.math.Offset
+
+import java.time.Duration
+
+import scala.xml.Node
+
+/** Decoder for the OCS2 sequence XML.
+  */
+object SequenceDecoder extends PioDecoder[List[Step]] {
+
+  def decode(n: Node): Either[PioError, List[Step]] =
+    (n \ "step").toList.scanLeft(EmptyConfigMap) { (m, stepNode) =>
+      stepNode.addStepConfig(m)
+    }.drop(1).traverse(parseStep)
+
+  private def parseStep(cm: ConfigMap): Either[PioError, Step] = {
+    def go(observeType: String, dc: DynamicConfig): Either[PioError, Step] =
+      observeType match {
+        case "BIAS" =>
+          dc.toStep(Step.Base.Bias).asRight
+
+        case "DARK" =>
+          dc.toStep(Step.Base.Dark).asRight
+
+        case "OBJECT" | "CAL" =>
+          for {
+            p <- Legacy.Telescope.P.cparseOrElse(cm, Offset.P.Zero)
+            q <- Legacy.Telescope.Q.cparseOrElse(cm, Offset.Q.Zero)
+          } yield dc.toStep(Step.Base.Science(TelescopeConfig(p, q)))
+
+        case "ARC" | "FLAT" =>
+          import Legacy.Calibration._
+          for {
+            l <- Lamp.parse(cm)
+            f <- Filter.parse(cm)
+            d <- Diffuser.parse(cm)
+            s <- Shutter.parse(cm)
+            e <- ExposureTime.parse(cm)
+            c <- CoAdds.parse(cm)
+          } yield dc.toStep(Step.Base.Gcal(GcalConfig(l, f, d, s, e, c)))
+
+        case x =>
+          PioError.parseError(x, "ObserveType").asLeft
+      }
+
+    for {
+      o <- Legacy.Observe.ObserveType.cparseOrElse(cm, "OBJECT")
+      i <- Legacy.Instrument.Instrument.parse(cm)
+      c <- parseInstConfig(i, cm)
+      s <- go(o, c)
+    } yield s
+  }
+
+  private def parseInstConfig(i: Instrument, cm: ConfigMap): Either[PioError, DynamicConfig] =
+    i match {
+      case Instrument.AcqCam     => DynamicConfig.AcqCam()  .asRight
+      case Instrument.Bhros      => DynamicConfig.Bhros()   .asRight
+
+      case Instrument.Flamingos2 => Flamingos2.parse(cm)
+      case Instrument.Ghost      => DynamicConfig.Ghost()   .asRight
+      case Instrument.GmosN      => Gmos.parseNorth(cm)
+      case Instrument.GmosS      => Gmos.parseSouth(cm)
+      case Instrument.Gnirs      => Gnirs.parse(cm)
+
+      case Instrument.Gpi        => DynamicConfig.Gpi()     .asRight
+      case Instrument.Gsaoi      => DynamicConfig.Gsaoi()   .asRight
+      case Instrument.Michelle   => DynamicConfig.Michelle().asRight
+      case Instrument.Nici       => DynamicConfig.Nici()    .asRight
+      case Instrument.Nifs       => DynamicConfig.Nifs()    .asRight
+      case Instrument.Niri       => DynamicConfig.Niri()    .asRight
+      case Instrument.Phoenix    => DynamicConfig.Phoenix() .asRight
+      case Instrument.Trecs      => DynamicConfig.Trecs()   .asRight
+      case Instrument.Visitor    => DynamicConfig.Visitor() .asRight
+    }
+
+  private object Flamingos2 {
+    def parse(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Flamingos2._
+      for {
+        d <- Disperser.parse(cm)
+        e <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Duration.ofMillis(0))
+        f <- Filter.parse(cm)
+        u <- Fpu.parse(cm)
+        l <- LyotWheel.parse(cm)
+        r <- ReadMode.parse(cm)
+        w <- WindowCover.cparseOrElse(cm, F2WindowCover.Close)
+      } yield DynamicConfig.Flamingos2(d, e, f, u, l, r, w)
+    }
+  }
+
+  private object Gmos {
+    import gem.config.GmosConfig.{ GmosCcdReadout, GmosCommonDynamicConfig, GmosCustomMask, GmosGrating }
+    import DynamicConfig.{ GmosN, GmosS }
+
+    def common(cm: ConfigMap): Either[PioError, GmosCommonDynamicConfig] = {
+      import Legacy.Instrument.Gmos._
+
+      for {
+        x  <- XBinning.parse(cm)
+        y  <- YBinning.parse(cm)
+        ac <- AmpCount.parse(cm)
+        ag <- AmpGain.parse(cm)
+        ar <- AmpReadMode.parse(cm)
+        dx <- Dtax.parse(cm)
+        e  <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Duration.ofMillis(0))
+        r  <- Roi.parse(cm)
+      } yield GmosCommonDynamicConfig(GmosCcdReadout(x, y, ac, ag, ar), dx, e, r)
+    }
+
+    def customMask(cm: ConfigMap): Either[PioError, Option[GmosCustomMask]] = {
+      import gem.ocs2.Legacy.Instrument.Gmos.{CustomMaskMdf, CustomSlitWidth}
+
+      (for {
+        f <- CustomMaskMdf.oparse(cm)
+        s <- PioOptional(CustomSlitWidth.parse(cm))
+      } yield GmosCustomMask(f, s)).value
+    }
+
+    def parseNorth(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Gmos._
+      import Legacy.Instrument.GmosNorth._
+
+      val grating: Either[PioError, Option[GmosGrating[GmosNorthDisperser]]] =
+        (for {
+          d <- PioOptional(Disperser.parse(cm))
+          o <- DisperserOrder.oparse(cm)
+          w <- DisperserLambda.oparse(cm)
+        } yield GmosGrating(d, o, w)).value
+
+      for {
+        c <- common(cm)
+        g <- grating
+        f <- Filter.parse(cm)
+        u <- Fpu.cparse(cm).map(_.flatten)
+        m <- customMask(cm)
+        fpu = u.map(_.asRight[GmosCustomMask]) orElse m.map(_.asLeft[GmosNorthFpu])
+      } yield GmosN(c, g, f, fpu)
+    }
+
+    def parseSouth(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Gmos._
+      import Legacy.Instrument.GmosSouth._
+
+      val grating: Either[PioError, Option[GmosGrating[GmosSouthDisperser]]] =
+        (for {
+          d <- PioOptional(Disperser.parse(cm))
+          o <- DisperserOrder.oparse(cm)
+          w <- DisperserLambda.oparse(cm)
+        } yield GmosGrating(d, o, w)).value
+
+      for {
+        c <- common(cm)
+        g <- grating
+        f <- Filter.parse(cm)
+        u <- Fpu.cparse(cm).map(_.flatten)
+        m <- customMask(cm)
+        fpu = u.map(_.asRight[GmosCustomMask]) orElse m.map(_.asLeft[GmosSouthFpu])
+      } yield GmosS(c, g, f, fpu)
+    }
+  }
+
+  private object Gnirs {
+    def parse(cm: ConfigMap): Either[PioError, DynamicConfig] = {
+      import Legacy.Instrument.Gnirs._
+      import gem.config.DynamicConfig.Gnirs.Default
+
+      for {
+        a <- AcquisitionMirror.parse(cm)
+        b <- Camera.parse(cm)
+        c <- CoAdds.parse(cm)
+        d <- Decker.cparseOrElse(cm, Default.decker)
+        e <- Disperser.parse(cm)
+        f <- Legacy.Observe.ExposureTime.cparseOrElse(cm, Default.exposureTime)
+        g <- Filter.cparseOrElse(cm, Default.filter)
+        h <- Fpu.parse(cm)
+        i <- Prism.parse(cm)
+        j <- ReadMode.parse(cm)
+        k <- Wavelength.parse(cm)
+      } yield DynamicConfig.Gnirs(a, b, c, d, e, f, g, h, i, j, k)
+    }
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/SmartGcalImporter.scala
@@ -1,0 +1,244 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.effect.Blocker
+import cats.effect.IO
+import cats.implicits._
+import fs2.Stream
+import fs2.{io, text}
+import gem.Log
+import gem.config.GcalConfig
+import gem.config.SmartGcalKey
+import gem.dao.{DatabaseConfiguration, SmartGcalDao, UserDao}
+import gem.enum.{GcalBaselineType, GcalLampType}
+import gem.ocs2.pio.PioParse
+import gsp.math.Wavelength
+
+import java.io.File
+import java.time.Duration
+import doobie._
+import doobie.implicits._
+
+import scala.reflect.runtime.universe._
+
+
+/** Importer for SmartGcal CSV files.  Note, these files use display values in
+  * some cases instead of the seqexec values since they were meant to be edited
+  * by science staff.
+  */
+object SmartGcalImporter extends DoobieClient {
+
+  private val xa = DatabaseConfiguration.forTesting.transactor[IO]
+
+  implicit class ParseOps(s: String) {
+    def parseAs[A: TypeTag](parse: PioParse[A]): A =
+      parse(s).getOrElse {
+        sys.error(s"Could not parse '$s' as ${typeOf[A]}")
+      }
+  }
+
+  // KeyParser accepts a list of String entries, parses the first n entries
+  // into a SmartGcalDefinitionKey and returns it along with the remaining
+  // entries.
+  type KeyParser[K]       = (List[String]) => (K, List[String])
+  type SmartGcalLine[K]   = (GcalLampType, GcalBaselineType, K, GcalConfig)
+  type SmartGcalWriter[K] = (Vector[SmartGcalLine[K]]) => Stream[ConnectionIO, Int]
+
+  // --------------------------------------------------------------------------
+  // Add your instruments here.
+  // --------------------------------------------------------------------------
+
+  def importAllInst: IO[Unit] = {
+    import SmartGcalDao._
+
+    for {
+      _ <- importInst("Flamingos2", parseF2,        dropIndexF2,        bulkInsertF2,        createIndexF2       )
+      _ <- importInst("GMOS-N",     parseGmosNorth, dropIndexGmosNorth, bulkInsertGmosNorth, createIndexGmosNorth)
+      _ <- importInst("GMOS-S",     parseGmosSouth, dropIndexGmosSouth, bulkInsertGmosSouth, createIndexGmosSouth)
+      _ <- importInst("GNIRS",      parseGnirs,     dropIndexGnirs,     bulkInsertGnirs,     createIndexGnirs)
+    } yield ()
+  }
+
+  def parseF2(input: List[String]): (SmartGcalKey.Flamingos2, List[String]) = {
+    import Parsers.Flamingos2._
+
+    val disperserS :: filterS :: fpuS :: gcal = input
+
+    val d = disperserS.parseAs(disperser)
+    val f = filterS   .parseAs(filter   )
+    val u = fpuS      .parseAs(fpu      ).flatMap(_.toBuiltin)
+
+    (SmartGcalKey.Flamingos2(d, f, u), gcal)
+  }
+
+  def parseGmosNorth(input: List[String]): (SmartGcalKey.GmosNorthDefinition, List[String]) = {
+    import Parsers.Gmos._
+    import Parsers.GmosNorth._
+
+    val disperserS :: filterS :: fpuS :: xBinS :: yBinS :: _ :: ampGainS :: wavelengthMinS :: wavelengthMaxS :: gcal = input
+
+    val d = disperserS.parseAs(disperser)
+    val f = filterS   .parseAs(filter   )
+    val u = fpuS      .parseAs(fpu)
+    val x = xBinS     .parseAs(xBinning)
+    val y = yBinS     .parseAs(yBinning)
+    val a = ampGainS  .parseAs(ampGain)
+
+    val c = SmartGcalKey.GmosCommon(d, f, u, x, y, a)
+
+    val wmin = wavelengthMinS.parseAs(Parsers.angstroms)
+    val wmax = parseMaxWavelength(wavelengthMaxS)
+
+    (SmartGcalKey.GmosDefinition(c, (wmin, wmax)), gcal)
+  }
+
+  def parseGmosSouth(input: List[String]): (SmartGcalKey.GmosSouthDefinition, List[String]) = {
+    import Parsers.Gmos._
+    import Parsers.GmosSouth._
+
+    val disperserS :: filterS :: fpuS :: xBinS :: yBinS :: _ :: ampGainS :: wavelengthMinS :: wavelengthMaxS :: gcal = input
+
+    val d = disperserS.parseAs(disperser)
+    val f = filterS   .parseAs(filter   )
+    val u = fpuS      .parseAs(fpu)
+    val x = xBinS     .parseAs(xBinning)
+    val y = yBinS     .parseAs(yBinning)
+    val a = ampGainS  .parseAs(ampGain)
+
+    val c = SmartGcalKey.GmosCommon(d, f, u, x, y, a)
+
+    val wmin = wavelengthMinS.parseAs(Parsers.angstroms)
+    val wmax = parseMaxWavelength(wavelengthMaxS)
+
+    (SmartGcalKey.GmosDefinition(c, (wmin, wmax)), gcal)
+  }
+
+  def parseGnirs(input: List[String]): (SmartGcalKey.GnirsDefinition, List[String]) = {
+    import Parsers.Gnirs._
+    import Parsers.Gnirs.SmartGcal
+
+    val modeS :: pixelScaleS :: disperserS :: crossDispersedS :: slitWidthS :: wellDepthS :: wavelengthMinS :: wavelengthMaxS :: gcal = input
+
+    val a = modeS          .parseAs(SmartGcal.mode)
+    val b = pixelScaleS    .parseAs(SmartGcal.pixelScale)
+    val c = disperserS     .parseAs(disperser)
+    val d = slitWidthS     .parseAs(fpu)
+    val e = crossDispersedS.parseAs(prism)
+    val f = wellDepthS     .parseAs(wellDepth)
+
+    val k = SmartGcalKey.Gnirs(a, b, c, d, e, f)
+
+    val wmin = wavelengthMinS.parseAs(Parsers.angstroms)
+    val wmax = parseMaxWavelength(wavelengthMaxS)
+
+    (SmartGcalKey.GnirsDefinition(k, (wmin, wmax)), gcal)
+
+  }
+
+  // -------------------------------------------------------------------------
+  // Implementation Details
+  // -------------------------------------------------------------------------
+
+  // Where to look for smart gcal csv files.
+  val dir: File = new File("smartgcal")
+
+  /** Obtains the file name to use for the given instrument name and lamp type.
+    *
+    * @param prefix file name prefix, which is extended with "_ARC.csv" and
+    *               "_FLAT.csv" to create the full file names.
+    * @param lampType flat or arc
+    * @return corresponding .csv file
+    */
+  def fileName(prefix: String, lampType: GcalLampType): String =
+    s"${prefix}_${lampType.tag.toUpperCase}.csv"
+
+  val checkSmartDir: IO[Unit] =
+    IO(dir.isDirectory).flatMap { b =>
+      IO(if (b) () else sys.error(
+        """
+          |** Root of project needs a "smartgcal/" dir with smart gcal config files in it.
+          |** Try ln -s /path/to/some/smart/gcal smartgcal
+          |** (for example ~/.ocs15/Gemini\ OT\ 2017A.1.1.1_mac/data/jsky.app.ot/smartgcal)
+        """.stripMargin))
+    }
+
+  /** Truncates all the smart gcal tables. */
+  val clean: ConnectionIO[Unit] =
+    sql"TRUNCATE gcal CASCADE".update.run.void
+
+  def parseMaxWavelength(s: String): Wavelength =
+    s match {
+      case "MAX" => Wavelength.Max
+      case _     => s.parseAs(Parsers.angstroms)
+    }
+
+  def parseGcal(input: List[String]): (GcalBaselineType, GcalConfig) = {
+    import Parsers.Calibration._
+
+    val _ :: filterS :: diffuserS :: lampS :: shutterS :: expS :: coaddsS :: baselineS :: Nil = input
+
+    val l = lampS.replaceAll(";", ",").parseAs(lamp)
+    val f = filterS  .parseAs(filter  )
+    val d = diffuserS.parseAs(diffuser)
+    val s = shutterS .parseAs(shutter )
+    val e = Duration.ofMillis(expS.parseAs(PioParse.long))
+    val c = coaddsS  .parseAs(Parsers.coadds)
+
+    val b = baselineS.parseAs(baseline)
+
+    (b, GcalConfig(l, f, d, s, e, c))
+  }
+
+
+  def parseLine[K](input: List[String], l: GcalLampType, parser: KeyParser[K]): SmartGcalLine[K] = {
+    val (k, r) = parser(input)
+    val (b, g) = parseGcal(r)
+    (l, b, k, g)
+  }
+
+  def importInst[K](instFilePrefix: String,
+                    parser:         KeyParser[K],
+                    unindexer:      ConnectionIO[Int],
+                    writer:         SmartGcalWriter[K],
+                    indexer:        ConnectionIO[Int]): IO[Unit] = {
+
+    def lines(l: GcalLampType): Stream[IO, SmartGcalLine[K]] =
+      Stream.eval(Blocker[IO].use { bec =>
+        IO(io.file.readAll[IO](new File(dir, fileName(instFilePrefix, l)).toPath, bec, 4096)
+            .through(text.utf8Decode)
+            .through(text.lines)
+            .filter(_.trim.nonEmpty)
+            .map(_.split(',').map(_.trim).toList)
+            .map(parseLine(_, l, parser)))
+      }).flatten
+
+    val prog = (lines(GcalLampType.Arc) ++ lines(GcalLampType.Flat))
+      .chunkN(4096)
+      .flatMap { c => writer(c.toVector).transact(xa) }
+
+    for {
+      _ <- IO(println(s"Importing $instFilePrefix ...")) // scalastyle:ignore
+      _ <- unindexer.transact(xa)
+      _ <- prog.compile.drain
+      _ <- indexer.transact(xa)
+    } yield ()
+  }
+
+  def runc: IO[Unit] =
+    for {
+      _ <- UserDao.selectRootUser.transact(xa)
+      l <- Log.newLog[IO]("smartgcal importer", xa)
+      _ <- checkSmartDir
+      _ <- configureLogging[IO]
+      _ <- clean.transact(xa)
+      _ <- importAllInst
+      _ <- l.shutdown(5 * 1000)
+      _ <- IO(println("Done.")) // scalastyle:ignore
+    } yield ()
+
+  def main(args: Array[String]): Unit =
+    runc.unsafeRunSync
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/StaticDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/StaticDecoder.scala
@@ -1,0 +1,113 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+
+import gem.config._
+import gem.enum._
+import gem.ocs2.pio._
+import gem.ocs2.pio.PioError.missingKey
+import gsp.math.Offset
+
+import scala.xml.Node
+
+/** Decoder for the OCS2 static configuration XML.
+  */
+object StaticDecoder extends PioDecoder[StaticConfig] {
+
+  def decode(n: Node): Either[PioError, StaticConfig] =
+    for {
+      cm <- ((n \ "step").headOption toRight missingKey("step")).map(_.toStepConfig)
+      i  <- Legacy.Instrument.Instrument.parse(cm)
+      sc <- parseStaticConfig(i, cm)
+    } yield sc
+
+
+  private def parseStaticConfig(i: Instrument, cm: ConfigMap): Either[PioError, StaticConfig] =
+    i match {
+      case Instrument.AcqCam     => StaticConfig.AcqCam()  .asRight
+      case Instrument.Bhros      => StaticConfig.Bhros()   .asRight
+
+      case Instrument.Flamingos2 => Flamingos2.parse(cm)
+      case Instrument.Ghost      => StaticConfig.Ghost()   .asRight
+      case Instrument.GmosN      => Gmos.parseNorth(cm)
+      case Instrument.GmosS      => Gmos.parseSouth(cm)
+      case Instrument.Gnirs      => Gnirs.parse(cm)
+
+      case Instrument.Gpi        => StaticConfig.Gpi()     .asRight
+      case Instrument.Gsaoi      => StaticConfig.Gsaoi()   .asRight
+      case Instrument.Michelle   => StaticConfig.Michelle().asRight
+      case Instrument.Nici       => StaticConfig.Nici()    .asRight
+      case Instrument.Nifs       => StaticConfig.Nifs()    .asRight
+      case Instrument.Niri       => StaticConfig.Niri()    .asRight
+      case Instrument.Phoenix    => StaticConfig.Phoenix() .asRight
+      case Instrument.Trecs      => StaticConfig.Trecs()   .asRight
+      case Instrument.Visitor    => StaticConfig.Visitor() .asRight
+    }
+
+  private object Flamingos2 {
+    def parse(cm: ConfigMap): Either[PioError, StaticConfig] =
+      Legacy.Instrument.MosPreImaging.parse(cm).map(StaticConfig.Flamingos2(_))
+  }
+
+  private object Gmos {
+    import gem.config.GmosConfig.{ GmosCommonStaticConfig, GmosCustomRoiEntry, GmosNodAndShuffle }
+    import StaticConfig.{ GmosN, GmosS }
+
+    def parseCustomRoiEntry(cm: ConfigMap, index: Int): Either[PioError, Option[GmosCustomRoiEntry]] = {
+      import Legacy.Instrument.Gmos._
+
+      (for {
+        xMin <- roiXMin(index).oparse(cm)
+        yMin <- roiYMin(index).oparse(cm)
+        xRng <- roiXRange(index).oparse(cm)
+        yRng <- roiYRange(index).oparse(cm)
+      } yield GmosCustomRoiEntry.unsafeFromDescription(xMin, yMin, xRng, yRng)).value
+    }
+
+    def parseCustomRoiEntries(cm: ConfigMap): Either[PioError, Set[GmosCustomRoiEntry]] =
+      (1 to 5).toList.traverse(parseCustomRoiEntry(cm, _)).map(_.flatMap(_.toList).toSet)
+
+    def parseNodAndShuffle(cm: ConfigMap): Either[PioError, Option[GmosNodAndShuffle]] = {
+      import Legacy.Instrument.Gmos._
+
+      (for {
+        ap <- NsBeamAp.oparse(cm)
+        aq <- NsBeamAq.oparse(cm)
+        bp <- NsBeamBp.oparse(cm)
+        bq <- NsBeamBq.oparse(cm)
+        eo <- EOffsetting.oparse(cm)
+        sf <- NsShuffle.oparse(cm)
+        cy <- NsCycles.oparse(cm)
+      } yield GmosNodAndShuffle(Offset(ap, aq), Offset(bp, bq), eo, sf, cy)).value
+    }
+
+    def parseCommonStatic(cm: ConfigMap): Either[PioError, GmosCommonStaticConfig] =
+      for {
+        d <- Legacy.Instrument.Gmos.Detector.parse(cm)
+        m <- Legacy.Instrument.MosPreImaging.parse(cm)
+        n <- parseNodAndShuffle(cm)
+        r <- parseCustomRoiEntries(cm)
+      } yield GmosCommonStaticConfig(d, m, n, r)
+
+    def parseNorth(cm: ConfigMap): Either[PioError, StaticConfig] =
+      for {
+        c <- parseCommonStatic(cm)
+        s <- Legacy.Instrument.GmosNorth.StageMode.parse(cm)
+      } yield GmosN(c, s)
+
+    def parseSouth(cm: ConfigMap): Either[PioError, StaticConfig] =
+      for {
+        c <- parseCommonStatic(cm)
+        s <- Legacy.Instrument.GmosSouth.StageMode.parse(cm)
+      } yield GmosS(c, s)
+  }
+
+  private object Gnirs {
+    def parse(cm: ConfigMap): Either[PioError, StaticConfig] =
+      Legacy.Instrument.Gnirs.WellDepth.parse(cm).map(StaticConfig.Gnirs(_))
+  }
+
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/package.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/package.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import scala.collection.immutable.TreeMap
+import scala.xml.Node
+
+package object ocs2 {
+  type ConfigMap = TreeMap[String, String]
+
+  val EmptyConfigMap: TreeMap[String, String] =
+    TreeMap.empty
+
+  /** Adds support for parsing steps into ConfigMap.  This is required by the
+    * SequenceDecoder and the StaticDecoder.
+    */
+  implicit class StepNodeOps(step: Node) {
+
+    /** Adds the configuration contained in this step node to the given
+      * ConfigMap, updating any values there as necessary.
+      */
+    def addStepConfig(cm: ConfigMap): ConfigMap = {
+      def addSysConfig(cm: ConfigMap, sys: Node): ConfigMap = {
+        val sysName = (sys \ "@name").text
+
+        (sys \ "param").foldLeft(cm) { (map, param) =>
+          val paramName  = (param \ "@name" ).text
+          val paramValue = (param \ "@value").text
+          map + (s"$sysName:$paramName" -> paramValue)
+        }
+      }
+
+      (step \ "system").foldLeft(cm)(addSysConfig)
+    }
+
+    /** Creates a ConfigMap containing just the configuration at this step.
+      */
+    def toStepConfig: ConfigMap =
+      addStepConfig(EmptyConfigMap)
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioDecoder.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioDecoder.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+import cats.Functor
+import java.time.Instant
+import shapeless.Typeable
+import scala.xml.Node
+
+import PioError._
+
+/** Typeclass for decoders of PIO-ish XML exported from an OCS2 database.
+  */
+trait PioDecoder[A] {
+  def decode(n: Node): Either[PioError, A]
+}
+
+object PioDecoder {
+
+  // N.B. as of 2.12 we can also us this method to *construct* a decoder by passing a
+  // `Node => Either[PioError, A])` which conforms with SAM interface PioDecoder[A] (!)
+  def apply[A](implicit ev: PioDecoder[A]): PioDecoder[A] = ev
+
+  def enum[A: Typeable](m: (String, A)*): PioDecoder[A] =
+    fromParseFunction[A] { m.toMap.lift }
+
+  def fromParse[A: Typeable](parse: PioParse[A]): PioDecoder[A] =
+    fromParseFunction(parse.run)
+
+  def fromParseFunction[A](parse: String => Option[A])(implicit ev: Typeable[A]): PioDecoder[A] =
+    new PioDecoder[A] {
+      def decode(n: Node): Either[PioError, A] =
+        parse(n.text) toRight ParseError(n.text, ev.describe)
+    }
+
+  implicit val FunctorPioDecoder: Functor[PioDecoder] =
+    new Functor[PioDecoder] {
+      def map[A, B](da: PioDecoder[A])(f: A => B): PioDecoder[B] =
+        PioDecoder(n => da.decode(n).map(f))
+    }
+
+  implicit def decode2[A, B](implicit da: PioDecoder[A], db: PioDecoder[B]): PioDecoder[(A, B)] =
+    PioDecoder { n =>
+      for {
+        a <- da.decode(n)
+        b <- db.decode(n)
+      } yield (a, b)
+    }
+
+  implicit def decode3[A, B, C](implicit da: PioDecoder[A], db: PioDecoder[B], dc: PioDecoder[C]): PioDecoder[(A, B, C)] =
+    PioDecoder { n =>
+      for {
+        a <- da.decode(n)
+        b <- db.decode(n)
+        c <- dc.decode(n)
+      } yield (a, b, c)
+    }
+
+  implicit val DoubleDecoder: PioDecoder[Double]   = fromParse(PioParse.double )
+  implicit val StringDecoder: PioDecoder[String]   = fromParse(PioParse.string )
+  implicit val IntDecoder: PioDecoder[Int]         = fromParse(PioParse.int    )
+  implicit val LongDecoder: PioDecoder[Long]       = fromParse(PioParse.long   )
+  implicit val InstantDecoder: PioDecoder[Instant] = fromParse(PioParse.instant)
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioError.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioError.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+sealed trait PioError extends Product with Serializable
+
+object PioError {
+  final case class MissingKey(name: String)                    extends PioError
+  final case class ParseError(value: String, dataType: String) extends PioError
+
+  def missingKey(name: String): PioError                    = MissingKey(name)
+  def parseError(value: String, dataType: String): PioError = ParseError(value, dataType)
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/PioPath.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/PioPath.scala
@@ -1,0 +1,270 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+import cats.Monoid
+import cats.implicits._
+import gem.ocs2.pio.PioError._
+
+import scala.xml.{Node, NodeSeq}
+
+/** PioPath provides a simplistic DSL for working with the OCS3 export format
+  * for OCS2 data. The language consists of an operator:
+  *
+  *  - `\!`  - required element
+  *  - `\?`  - optional element
+  *  - `\*`  - list of immediate child elements
+  *  - `\\*` - list of descendent elements
+  *
+  *  and a corresponding match string where the initial character is:
+  *
+  *  - '@' - attribute element
+  *  - '#' - `param` element with the given name
+  *  - '&' - `paramset` element with the given name
+  *  - ``  - (i.e., no special character) child element
+  *
+  * Example:
+  *
+  * {{{
+  *  (n \?  "instrument" \! "@type")
+  * }}}
+  *
+  * Node with an optional <instrument>` element that, if it exists, has a
+  * required "type" attribute.  When decoded, any path that included a `?`
+  * but not a `*` will produce an `Option` result.  Any path including a
+  * `*` will produce a `List`.
+  *
+  * If a required element is missing, the result will be `MissingKey`
+  * `PioError` when decoded.
+  */
+object PioPath {
+
+  implicit class NodeOps(n: Node) {
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, A] =
+      ev.decode(n)
+
+    def attr(name: String): Option[Node] =
+      (n \ s"@$name").headOption
+
+    def name: Option[String] =
+      Some((n \ "@name").text).filterNot(_.isEmpty)
+
+    def value: Option[Node] =
+      (n \ "value").headOption orElse (n \ "@value").headOption
+
+    private def filterByName(ns: NodeSeq, name: String): List[Node] =
+      ns.filter(_.name.contains(name)).toList
+
+    private def lookupParamValues(ns: NodeSeq, name: String): List[Node] =
+      for {
+        p <- filterByName(ns, name)
+        v <- p.value.toList
+      } yield v
+
+    def param(name: String): Option[Node] =
+      lookupParamValues(n \ "param", name).headOption
+
+    def params(name: String): List[Node] =
+      lookupParamValues(n \ "param", name)
+
+    def deepParams(name: String): List[Node] =
+      lookupParamValues(n \\ "param", name)
+
+    def paramset(name: String): Option[Node] =
+      paramsets(name).headOption
+
+    def paramsets(name: String): List[Node] =
+      filterByName(n \ "paramset", name)
+
+    def deepParamsets(name: String): List[Node] =
+      filterByName(n \\ "paramset", name)
+
+    def toRequired: Required =
+      Required(EmptySearchPath, n.asRight)
+
+    private val root: Required = toRequired
+
+    def \!  (matchString: String): Required  = root \!  matchString
+    def \?  (matchString: String): Optional  = root \?  matchString
+    def \*  (matchString: String): Listing   = root \*  matchString
+    def \\* (matchString: String): Listing   = root \\* matchString
+  }
+
+  sealed trait SearchPath {
+    protected def append(symbol: String, matchString: String): SearchPath
+
+    def \!  (matchString: String): SearchPath = append("\\!",   matchString)
+    def \?  (matchString: String): SearchPath = append("\\?",   matchString)
+    def \*  (matchString: String): SearchPath = append("\\*",   matchString)
+    def \\* (matchString: String): SearchPath = append("\\\\*", matchString)
+
+    final override def toString: String =
+      this match {
+        case EmptySearchPath          => ""
+        case NonEmptySearchPath(path) => path
+      }
+
+  }
+
+  final case object EmptySearchPath extends SearchPath {
+    protected def append(symbol: String, matchString: String): SearchPath =
+      NonEmptySearchPath(s"$symbol $matchString")
+  }
+
+  final case class NonEmptySearchPath(path: String) extends SearchPath {
+    protected def append(symbol: String, matchString: String): SearchPath =
+      NonEmptySearchPath(s"$path $symbol $matchString")
+  }
+
+  trait Lookup {
+    def optional: Node => Option[Node]
+    def list:     Node => List[Node]
+    def deepList: Node => List[Node]
+  }
+
+  object Lookup {
+    def apply(s: String): Lookup =
+      s.splitAt(1) match {
+        case ("@", name) => Attr(name)
+        case ("#", name) => Param(name)
+        case ("&", name) => Paramset(name)
+        case _           => Child(s)
+      }
+  }
+
+  final case class Attr(name: String) extends Lookup {
+    def optional: Node => Option[Node] = _.attr(name)
+    def list:     Node => List[Node]   = _.child.toList.flatMap(_.attr(name).toList)
+    def deepList: Node => List[Node]   = _.descendant.toList.flatMap(_.attr(name).toList)
+  }
+
+  final case class Param(name: String) extends Lookup {
+    def optional: Node => Option[Node] = _.param(name)
+    def list:     Node => List[Node]   = _.params(name)
+    def deepList: Node => List[Node]   = _.deepParams(name)
+  }
+
+  final case class Paramset(name: String) extends Lookup {
+    def optional: Node => Option[Node] = _.paramset(name)
+    def list:     Node => List[Node]   = _.paramsets(name)
+    def deepList: Node => List[Node]   = _.deepParamsets(name)
+  }
+
+  final case class Child(name: String) extends Lookup {
+    def optional: Node => Option[Node] = n => (n \ name).headOption
+    def list:     Node => List[Node]   = n => (n \ name).toList
+    def deepList: Node => List[Node]   = n => (n \\ name).toList
+  }
+
+  final case class Required(path: SearchPath, node: Either[PioError, Node]) {
+
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, A] =
+      node.flatMap(ev.decode)
+
+    def \! (matchString: String): Required = {
+      val pathʹ = path \! matchString
+      val nodeʹ = node.flatMap { n =>
+        Lookup(matchString).optional(n) toRight missingKey(pathʹ.toString)
+      }
+      Required(pathʹ, nodeʹ)
+    }
+
+    def \? (matchString: String): Optional = {
+      val pathʹ = path \? matchString
+      val nodeʹ = PioOptional(node.map(Lookup(matchString).optional))
+      Optional(pathʹ, nodeʹ)
+    }
+
+    def \* (matchString: String): Listing = {
+      val pathʹ = path \* matchString
+      val nodeʹ = node.map(Lookup(matchString).list)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \\* (matchString: String): Listing = {
+      val pathʹ = path \\* matchString
+      val nodeʹ = node.map(Lookup(matchString).deepList)
+      Listing(pathʹ, nodeʹ)
+    }
+  }
+
+
+  final case class Optional(path: SearchPath, node: PioOptional[Node]) {
+
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, Option[A]] =
+      node.semiflatMap(ev.decode).value
+
+    def decodeOrZero[A : PioDecoder : Monoid]: Either[PioError, A] =
+      decode[A].map { _.orEmpty }
+
+    def decodeOrElse[A](a: => A)(implicit ev: PioDecoder[A]): Either[PioError, A] =
+      decode[A].map { _.getOrElse(a) }
+
+    def \! (matchString: String): Optional = {
+      val pathʹ = path \! matchString
+      val nodeʹ = node.semiflatMap { n =>
+        Lookup(matchString).optional(n) toRight missingKey(pathʹ.toString)
+      }
+      Optional(pathʹ, nodeʹ)
+    }
+
+    def \? (matchString: String): Optional = {
+      val pathʹ = path \? matchString
+      val nodeʹ = node.flatMap { n =>
+        PioOptional.fromOption(Lookup(matchString).optional(n))
+      }
+      Optional(pathʹ, nodeʹ)
+    }
+
+    private def listing(f: Node => List[Node]): Either[PioError, List[Node]] =
+      node.value.map(_.toList.flatMap(f))
+
+    def \* (matchString: String): Listing = {
+      val pathʹ = path \* matchString
+      val nodeʹ = listing(Lookup(matchString).list)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \\* (matchString: String): Listing = {
+      val pathʹ = path \\* matchString
+      val nodeʹ = listing(Lookup(matchString).deepList)
+      Listing(pathʹ, nodeʹ)
+    }
+  }
+
+
+  final case class Listing(path: SearchPath, node: Either[PioError, List[Node]]) {
+
+    def decode[A](implicit ev: PioDecoder[A]): Either[PioError, List[A]] =
+      node.flatMap { _.traverse(ev.decode) }
+
+    def \! (matchString: String): Listing = {
+      val pathʹ = path \! matchString
+      val f     = (n: Node) => Lookup(matchString).optional(n) toRight missingKey(pathʹ.toString)
+      val nodeʹ = node.flatMap { _.traverse(f) }
+      Listing(pathʹ, nodeʹ)
+    }
+
+    private def listing(f: Node => List[Node]): Either[PioError, List[Node]] =
+      node.map { _.flatMap(f) }
+
+    def \? (matchString: String): Listing = {
+      val pathʹ = path \? matchString
+      val nodeʹ = listing((n: Node) => Lookup(matchString).optional(n).toList)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \* (matchString: String): Listing = {
+      val pathʹ = path \* matchString
+      val nodeʹ = listing(Lookup(matchString).list)
+      Listing(pathʹ, nodeʹ)
+    }
+
+    def \\* (matchString: String): Listing = {
+      val pathʹ = path \\* matchString
+      val nodeʹ = listing(Lookup(matchString).deepList)
+      Listing(pathʹ, nodeʹ)
+    }
+  }
+}

--- a/modules/ocs2/src/main/scala/gem/ocs2/pio/package.scala
+++ b/modules/ocs2/src/main/scala/gem/ocs2/pio/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.data._, cats.implicits._
+
+package object pio {
+  type PioOptional[A] = OptionT[Either[PioError, ?], A]
+
+  object PioOptional {
+    def apply[A](a: Either[PioError, Option[A]]): PioOptional[A] =
+      OptionT[Either[PioError, ?], A](a)
+
+    def fromOption[A](oa: Option[A]): PioOptional[A] =
+      OptionT[Either[PioError, ?], A](oa.asRight)
+
+    def none[A]: PioOptional[A] =
+      OptionT.none[Either[PioError, ?], A]
+
+    def some[A](a: A): PioOptional[A] =
+      OptionT.some[Either[PioError, ?]](a)
+  }
+}

--- a/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
+++ b/modules/ocs2/src/test/scala/gem/ocs2/TargetDecodersTest.scala
@@ -1,0 +1,158 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import gem.{ EphemerisKey, Target }
+import gsp.math._
+import gem.ocs2.Decoders._
+import gem.ocs2.pio._
+import gem.ocs2.pio.PioError.{ MissingKey, ParseError }
+
+import cats.tests.CatsSuite
+
+import scala.xml._
+
+// Basic sanity checks for target decoding
+
+final class TargetDecodersTest extends CatsSuite {
+  import TargetDecodersTest._
+
+  test("Fully specified ProperMotion") {
+    PioDecoder[ProperMotion].decode(SiderealNode) match {
+      case Right(actual) => assert(actual == SiderealProperMotion)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Missing redshift") {
+    val xml = delete("redshift", SiderealNode)
+    val exp = SiderealProperMotion.copy(radialVelocity = None)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Right(actual) => assert(actual == exp)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Missing proper-motion") {
+    val xml = delete("proper-motion", SiderealNode)
+    val exp = SiderealProperMotion.copy(properVelocity = None)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Right(actual) => assert(actual == exp)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Missing delta-ra") {
+    val xml = delete("delta-ra", SiderealNode)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Left(MissingKey(m)) => assert(m.contains("delta-ra"))
+      case Right(_)            => fail("delta-ra is required if proper-motion is present")
+      case other               => fail(s"unexpected: $other")
+    }
+  }
+
+  test("Unexpected epoch year") {
+    val xml = setValue("epoch", "2017", SiderealNode)
+    PioDecoder[ProperMotion].decode(xml) match {
+      case Left(ParseError("2017", "Epoch")) => succeed
+      case Right(_)                          => fail("cannot handle epoch 2017")
+      case other                             => fail(s"unexpected: $other")
+    }
+  }
+
+  test("Sidereal target") {
+    PioDecoder[Target].decode(SiderealNode) match {
+      case Right(actual) => assert(actual == SiderealTarget)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+
+  test("Nonsidereal target") {
+    PioDecoder[Target].decode(NonsiderealNode) match {
+      case Right(actual) => assert(actual == NonsiderealTarget)
+      case Left(err)     => fail(err.toString)
+    }
+  }
+}
+
+object TargetDecodersTest {
+  val SiderealNode: Elem =
+    <paramset name="target">
+      <param name="name" value="Example"/>
+      <param name="redshift" value="4.0"/>
+      <param name="parallax" value="1.0"/>
+      <paramset name="magnitude">
+        <param name="value" value="17.0"/>
+        <param name="band" value="r"/>
+        <param name="system" value="AB"/>
+      </paramset>
+      <paramset name="coordinates">
+        <param name="ra" value="55.291666666666686"/>
+        <param name="dec" value="11.550000000000011"/>
+      </paramset>
+      <paramset name="proper-motion">
+        <param name="delta-ra" value="2.0"/>
+        <param name="delta-dec" value="3.0"/>
+        <param name="epoch" value="2000.0"/>
+      </paramset>
+      <param name="tag" value="sidereal"/>
+    </paramset>
+
+  val SiderealProperMotion: ProperMotion = {
+    val ra  = RightAscension.fromStringHMS.unsafeGet("03:41:10.000")
+    val dec = Declination.fromStringSignedDMS.unsafeGet("11:33:00.00")
+    val c   = Coordinates(ra, dec)
+
+    val off = Offset(
+                Offset.P(Angle.milliarcseconds.reverseGet(2)),
+                Offset.Q(Angle.milliarcseconds.reverseGet(3))
+              )
+
+    val rv  = RadialVelocity.unsafeFromRedshift(4.0)
+
+    val px  = Angle.milliarcseconds.reverseGet(1)
+
+    ProperMotion(c, Epoch.J2000, Some(off), Some(rv), Some(px))
+  }
+
+  val SiderealTarget: Target =
+    Target("Example", Right(SiderealProperMotion))
+
+  val NonsiderealNode: Elem =
+    <paramset name="target">
+      <param name="name" value="Oumuamua"/>
+      <paramset name="horizons-designation">
+        <param name="des" value="C/1937 P1"/>
+        <param name="tag" value="comet"/>
+      </paramset>
+      <param name="tag" value="nonsidereal"/>
+    </paramset>
+
+  val NonsiderealTarget: Target =
+    Target("Oumuamua", Left(EphemerisKey.Comet("C/1937 P1")))
+
+  // Deletes all instances of params and paramsets that have the given name.
+  private def delete(name: String, e: Elem): Elem = {
+    val children = e.child.filter(c => (c \ "@name").text != name)
+    e.copy(child = children.map {
+      case c: Elem => delete(name, c)
+      case other   => other
+    })
+  }
+
+  // Sets the value of a named "param" anywhere within the given element
+  private def setValue(name: String, value: String, e: Elem): Elem = {
+    val children = e.child.map {
+      case e: Elem if e.label == "param" && (e \ "@name").text == name =>
+          e.copy(attributes = new UnprefixedAttribute("name", name, new UnprefixedAttribute("value", value, Null)))
+
+      case otherChild: Elem =>
+        setValue(name, value, otherChild)
+
+      case otherNode        =>
+        otherNode
+    }
+    e.copy(child = children)
+  }
+}

--- a/modules/ocs2_api/src/main/scala/gem/ocs2/Parsers.scala
+++ b/modules/ocs2_api/src/main/scala/gem/ocs2/Parsers.scala
@@ -1,0 +1,725 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2
+
+import cats.implicits._
+import gem.CoAdds
+import gem.Dataset
+import gem.Observation
+import gem.Program
+import gem.enum._
+import gem.config.GcalConfig.GcalLamp
+import gsp.math._
+
+/** String parsers for our model types.
+  */
+object Parsers {
+
+  import gem.ocs2.pio.PioParse
+  import gem.ocs2.pio.PioParse._
+
+  val yesNo: PioParse[Boolean] = enum(
+    "No"  -> false,
+    "Yes" -> true
+  )
+
+  val mosPreImaging: PioParse[MosPreImaging] = enum(
+    "No"  -> MosPreImaging.IsNotMosPreImaging,
+    "Yes" -> MosPreImaging.IsMosPreImaging
+  )
+
+  val arcsec: PioParse[Angle] =
+    double.map(Angle.fromDoubleArcseconds)
+
+  val angstroms: PioParse[Wavelength] =
+    int.map(n => Wavelength.fromAngstroms.unsafeGet(n))
+
+  val magnitudeSystem: PioParse[MagnitudeSystem] =
+    enumFromTag(MagnitudeSystem.all)
+
+  val magnitudeBand: PioParse[MagnitudeBand] = enum(
+    "u"  -> MagnitudeBand.SloanU,
+    "g"  -> MagnitudeBand.SloanG,
+    "r"  -> MagnitudeBand.SloanR,
+    "i"  -> MagnitudeBand.SloanI,
+    "z"  -> MagnitudeBand.SloanZ,
+    "U"  -> MagnitudeBand.U,
+    "B"  -> MagnitudeBand.B,
+    "V"  -> MagnitudeBand.V,
+    "UC" -> MagnitudeBand.Uc,
+    "R"  -> MagnitudeBand.R,
+    "I"  -> MagnitudeBand.I,
+    "Y"  -> MagnitudeBand.Y,
+    "J"  -> MagnitudeBand.J,
+    "H"  -> MagnitudeBand.H,
+    "K"  -> MagnitudeBand.K,
+    "L"  -> MagnitudeBand.L,
+    "M"  -> MagnitudeBand.M,
+    "N"  -> MagnitudeBand.N,
+    "Q"  -> MagnitudeBand.Q,
+    "AP" -> MagnitudeBand.Ap
+  )
+
+  val ra: PioParse[RightAscension] =
+    double.map(Angle.fromDoubleDegrees)
+          .map(Angle.hourAngle.get)
+          .map(RightAscension.fromHourAngle.get)
+
+  val dec: PioParse[Declination] =
+    double.map(Angle.fromDoubleDegrees)
+          .map(Declination.fromAngle.unsafeGet)
+
+  // Anything else blows up, which is ok since we don't support anything else
+  val epoch: PioParse[Epoch] = enum(
+    "1950.0" -> Epoch.B1950,
+    "2000.0" -> Epoch.J2000
+  )
+
+  val ephemerisKeyType: PioParse[EphemerisKeyType] = enum(
+    "asteroid"           -> EphemerisKeyType.AsteroidNew,
+    "asteroid-old-style" -> EphemerisKeyType.AsteroidOld,
+    "comet"              -> EphemerisKeyType.Comet,
+    "major-body"         -> EphemerisKeyType.MajorBody
+  )
+
+  val instrument: PioParse[Instrument] = enum(
+    "AcqCam"     -> gem.enum.Instrument.AcqCam,
+    "bHROS"      -> gem.enum.Instrument.Bhros,
+    "BHROS"      -> gem.enum.Instrument.Bhros,
+    "Flamingos2" -> gem.enum.Instrument.Flamingos2,
+    "GMOS"       -> gem.enum.Instrument.GmosN,
+    "GMOS-N"     -> gem.enum.Instrument.GmosN,
+    "GMOSSouth"  -> gem.enum.Instrument.GmosS,
+    "GMOS-S"     -> gem.enum.Instrument.GmosS,
+    "GNIRS"      -> gem.enum.Instrument.Gnirs,
+    "GPI"        -> gem.enum.Instrument.Gpi,
+    "GSAOI"      -> gem.enum.Instrument.Gsaoi,
+    "Michelle"   -> gem.enum.Instrument.Michelle,
+    "NICI"       -> gem.enum.Instrument.Nici,
+    "NIFS"       -> gem.enum.Instrument.Nifs,
+    "NIRI"       -> gem.enum.Instrument.Niri,
+    "Phoenix"    -> gem.enum.Instrument.Phoenix,
+    "TReCS"      -> gem.enum.Instrument.Trecs,
+    "Visitor"    -> gem.enum.Instrument.Visitor,
+    "Visitor Instrument" -> gem.enum.Instrument.Visitor
+  )
+
+  val progId: PioParse[Program.Id] =
+    PioParse(Program.Id.fromString.getOption)
+
+  val obsId: PioParse[Observation.Id] =
+    PioParse(Observation.Id.fromString)
+
+  val datasetLabel: PioParse[Dataset.Label] =
+    PioParse(Dataset.Label.fromString.getOption)
+
+  val offsetP: PioParse[Offset.P] =
+    arcsec.map(Offset.P.apply)
+
+  val offsetQ: PioParse[Offset.Q] =
+    arcsec.map(Offset.Q.apply)
+
+  val userTargetType: PioParse[UserTargetType] = enum(
+    "blindOffset" -> UserTargetType.BlindOffset,
+    "offAxis"     -> UserTargetType.OffAxis,
+    "tuningStar"  -> UserTargetType.TuningStar,
+    "other"       -> UserTargetType.Other
+  )
+
+  val coadds: PioParse[CoAdds] = positiveShort.map(CoAdds.fromShort.unsafeGet)
+
+  object Calibration {
+
+    val lamp: PioParse[GcalLamp] = {
+      import GcalArc._
+      import GcalContinuum._
+
+      val lampToContinuum = Map[String, GcalContinuum](
+        "IR grey body - high" -> IrGreyBodyHigh,
+        "IR grey body - low"  -> IrGreyBodyLow,
+        "Quartz Halogen"      -> QuartzHalogen
+      ).lift
+
+      val lampToArc       = Map[String, GcalArc](
+        "Ar arc"              -> ArArc,
+        "CuAr arc"            -> CuArArc,
+        "ThAr arc"            -> ThArArc,
+        "Xe arc"              -> XeArc
+      ).lift
+
+      PioParse(lamps => {
+        val (continuum, arc) = lamps.split(',').foldLeft((List.empty[GcalContinuum], List.empty[GcalArc])) {
+          case ((cs,as), s) =>
+            val cs2 = lampToContinuum(s).fold(cs) { _ :: cs }
+            val as2 = lampToArc(s).fold(as) { _ :: as }
+            (cs2, as2)
+        }
+        GcalLamp.fromConfig(continuum.headOption, arc.tupleRight(true): _*)
+      })
+    }
+
+    val filter: PioParse[GcalFilter] = enum(
+      "none"         -> GcalFilter.None,
+      "ND1.0"        -> GcalFilter.Nd10,
+      "ND1.6"        -> GcalFilter.Nd16,
+      "ND2.0"        -> GcalFilter.Nd20,
+      "ND3.0"        -> GcalFilter.Nd30,
+      "ND4.0"        -> GcalFilter.Nd40,
+      "ND4-5"        -> GcalFilter.Nd45,
+      "ND5.0"        -> GcalFilter.Nd50,
+      "GMOS balance" -> GcalFilter.Gmos,
+      "HROS balance" -> GcalFilter.Hros,
+      "NIR balance"  -> GcalFilter.Nir
+    )
+
+    val diffuser: PioParse[GcalDiffuser] = enum(
+      "IR"      -> GcalDiffuser.Ir,
+      "visible" -> GcalDiffuser.Visible
+    )
+
+    val shutter: PioParse[GcalShutter] = enum(
+      "Closed" -> GcalShutter.Closed,
+      "Open"   -> GcalShutter.Open
+    )
+
+    val baseline: PioParse[GcalBaselineType] = enum(
+      "DAY"   -> GcalBaselineType.Day,
+      "NIGHT" -> GcalBaselineType.Night
+    )
+  }
+
+  object Flamingos2 {
+
+    import F2Disperser._
+
+    val disperser: PioParse[Option[F2Disperser]] = enum(
+      "NONE"    -> None,
+      "R1200HK" -> Some(R1200HK),
+      "R1200JH" -> Some(R1200JH),
+      "R3000"   -> Some(R3000)
+    )
+
+
+    import F2Filter._
+
+    val filter: PioParse[F2Filter] = enum(
+      "OPEN"    -> Open,
+      "DARK"    -> Dark,
+      "F1056"   -> F1056,
+      "F1063"   -> F1063,
+      "H"       -> H,
+      "HK"      -> HK,
+      "J"       -> J,
+      "J_LOW"   -> JLow,
+      "JH"      -> JH,
+      "K_LONG"  -> KLong,
+      "K_SHORT" -> KShort,
+      "K_BLUE"  -> KBlue,
+      "K_RED"   -> KRed,
+      "Y"       -> Y
+    )
+
+    import F2Fpu._
+    import gem.config.F2Config.F2FpuChoice
+    import gem.config.F2Config.F2FpuChoice.{ Builtin, Custom }
+
+    val fpu: PioParse[Option[F2FpuChoice]] = enum(
+      "PINHOLE"         -> Some(Builtin(Pinhole)),
+      "SUBPIX_PINHOLE"  -> Some(Builtin(SubPixPinhole)),
+      "FPU_NONE"        -> None,
+      "CUSTOM_MASK"     -> Some(Custom),
+      "LONGSLIT_1"      -> Some(Builtin(LongSlit1)),
+      "LONGSLIT_2"      -> Some(Builtin(LongSlit2)),
+      "LONGSLIT_3"      -> Some(Builtin(LongSlit3)),
+      "LONGSLIT_4"      -> Some(Builtin(LongSlit4)),
+      "LONGSLIT_6"      -> Some(Builtin(LongSlit6)),
+      "LONGSLIT_8"      -> Some(Builtin(LongSlit8))
+    )
+
+    import F2LyotWheel._
+
+    val lyotWheel: PioParse[F2LyotWheel] = enum(
+      "GEMS"       -> F33Gems,
+      "GEMS_OVER"  -> GemsUnder,
+      "GEMS_UNDER" -> GemsOver,
+      "H1"         -> HartmannA,
+      "H2"         -> HartmannB,
+      "HIGH"       -> F32High,
+      "LOW"        -> F32Low,
+      "OPEN"       -> F16
+    )
+
+    import F2ReadMode._
+    val readMode: PioParse[F2ReadMode] = enum(
+      "BRIGHT_OBJECT_SPEC" -> Bright,
+      "MEDIUM_OBJECT_SPEC" -> Medium,
+      "FAINT_OBJECT_SPEC"  -> Faint
+    )
+
+    val windowCover: PioParse[F2WindowCover] = enum(
+      "CLOSE" -> F2WindowCover.Close,
+      "OPEN"  -> F2WindowCover.Open
+    )
+  }
+
+
+  object Gmos {
+    import GmosAdc._
+
+    val adc: PioParse[Option[GmosAdc]] = enum(
+      "No Correction"          -> Option.empty[GmosAdc],
+      "Best Static Correction" -> Some(BestStatic),
+      "Follow During Exposure" -> Some(Follow)
+    )
+
+    import GmosAmpCount._
+
+    val ampCount: PioParse[GmosAmpCount] = enum(
+      "Three"  -> Three,
+      "Six"    -> Six,
+      "Twelve" -> Twelve
+    )
+
+    import GmosAmpGain._
+
+    val ampGain: PioParse[GmosAmpGain] = enum(
+      "Low"  -> Low,
+      "High" -> High
+    )
+
+    import GmosAmpReadMode._
+
+    val ampReadMode: PioParse[GmosAmpReadMode] = enum(
+      "Slow" -> Slow,
+      "Fast" -> Fast
+    )
+
+    import GmosCustomSlitWidth._
+
+    val customSlitWidth: PioParse[Option[GmosCustomSlitWidth]] = enum(
+      "OTHER"             -> Option.empty[GmosCustomSlitWidth],
+      "CUSTOM_WIDTH_0_25" -> Some(CustomWidth_0_25),
+      "CUSTOM_WIDTH_0_50" -> Some(CustomWidth_0_50),
+      "CUSTOM_WIDTH_0_75" -> Some(CustomWidth_0_75),
+      "CUSTOM_WIDTH_1_00" -> Some(CustomWidth_1_00),
+      "CUSTOM_WIDTH_1_50" -> Some(CustomWidth_1_50),
+      "CUSTOM_WIDTH_2_00" -> Some(CustomWidth_2_00),
+      "CUSTOM_WIDTH_5_00" -> Some(CustomWidth_5_00)
+    )
+
+    import GmosDetector._
+
+    val detector: PioParse[GmosDetector] = enum(
+      "E2V"       -> E2V,
+      "HAMAMATSU" -> HAMAMATSU
+    )
+
+    val disperserOrder: PioParse[GmosDisperserOrder] = enum(
+      "0" -> GmosDisperserOrder.Zero,
+      "1" -> GmosDisperserOrder.One,
+      "2" -> GmosDisperserOrder.Two
+    )
+
+    val disperserLambda: PioParse[Wavelength] =
+      double.map(d => Wavelength.fromAngstroms.unsafeGet((d * 10.0).round.toInt))
+
+    val dtax: PioParse[GmosDtax] = enum(
+      "-6" -> GmosDtax.MinusSix,
+      "-5" -> GmosDtax.MinusFive,
+      "-4" -> GmosDtax.MinusFour,
+      "-3" -> GmosDtax.MinusThree,
+      "-2" -> GmosDtax.MinusTwo,
+      "-1" -> GmosDtax.MinusOne,
+      "0"  -> GmosDtax.Zero,
+      "1"  -> GmosDtax.One,
+      "2"  -> GmosDtax.Two,
+      "3"  -> GmosDtax.Three,
+      "4"  -> GmosDtax.Four,
+      "5"  -> GmosDtax.Five,
+      "6"  -> GmosDtax.Six
+    )
+
+    val nsEOffsetting: PioParse[GmosEOffsetting] = enum(
+      "true"  -> GmosEOffsetting.On,
+      "false" -> GmosEOffsetting.Off
+    )
+
+    import gem.config.GmosConfig.GmosShuffleOffset
+
+    val nsShuffle: PioParse[GmosShuffleOffset] =
+      positiveInt.map(GmosShuffleOffset.unsafeFromRowCount)
+
+    import gem.config.GmosConfig.GmosShuffleCycles
+
+    val nsCycles: PioParse[GmosShuffleCycles] =
+      positiveInt.map(GmosShuffleCycles.unsafeFromCycleCount)
+
+    import GmosRoi._
+
+    val roi: PioParse[GmosRoi] = enum(
+      "Custom ROI"         -> Custom,
+      "Full Frame Readout" -> FullFrame,
+      "CCD 2"              -> Ccd2,
+      "Central Spectrum"   -> CentralSpectrum,
+      "Central Stamp"      -> CentralStamp,
+      "Top Spectrum"       -> TopSpectrum,
+      "Bottom Spectrum"    -> BottomSpectrum
+    )
+
+    val xBinning: PioParse[GmosXBinning] = enum(
+      "1" -> GmosXBinning.One,
+      "2" -> GmosXBinning.Two,
+      "4" -> GmosXBinning.Four
+    )
+
+    val yBinning: PioParse[GmosYBinning] = enum(
+      "1" -> GmosYBinning.One,
+      "2" -> GmosYBinning.Two,
+      "4" -> GmosYBinning.Four
+    )
+  }
+
+  object GmosNorth {
+    import GmosNorthDisperser._
+
+    val disperser: PioParse[Option[GmosNorthDisperser]] = enum(
+      "Mirror"      -> Option.empty[GmosNorthDisperser],
+      "B1200_G5301" -> Some(B1200_G5301),
+      "R831_G5302"  -> Some(R831_G5302 ),
+      "B600_G5303"  -> Some(B600_G5303 ),
+      "B600_G5307"  -> Some(B600_G5307 ),
+      "R600_G5304"  -> Some(R600_G5304 ),
+      "R400_G5305"  -> Some(R400_G5305 ),
+      "R150_G5306"  -> Some(R150_G5306 ),
+      "R150_G5308"  -> Some(R150_G5308 )
+    )
+
+    import GmosNorthFilter._
+
+    val filter: PioParse[Option[GmosNorthFilter]] = enum(
+      "None"                      -> Option.empty[GmosNorthFilter],
+      "g_G0301"                   -> Some(GPrime),
+      "r_G0303"                   -> Some(RPrime),
+      "i_G0302"                   -> Some(IPrime),
+      "z_G0304"                   -> Some(ZPrime),
+      "Z_G0322"                   -> Some(Z),
+      "Y_G0323"                   -> Some(Y),
+      "GG455_G0305"               -> Some(GG455),
+      "OG515_G0306"               -> Some(OG515),
+      "RG610_G0307"               -> Some(RG610),
+      "CaT_G0309"                 -> Some(CaT),
+      "Ha_G0310"                  -> Some(Ha),
+      "HaC_G0311"                 -> Some(HaC),
+      "DS920_G0312"               -> Some(DS920),
+      "SII_G0317"                 -> Some(SII),
+      "OIII_G0318"                -> Some(OIII),
+      "OIIIC_G0319"               -> Some(OIIIC),
+      "HeII_G0320"                -> Some(HeII),
+      "HeIIC_G0321"               -> Some(HeIIC),
+      "HartmannA_G0313 + r_G0303" -> Some(HartmannA_RPrime),
+      "HartmannB_G0314 + r_G0303" -> Some(HartmannB_RPrime),
+      "g_G0301 + GG455_G0305"     -> Some(GPrime_GG455),
+      "g_G0301 + OG515_G0306"     -> Some(GPrime_OG515),
+      "r_G0303 + RG610_G0307"     -> Some(RPrime_RG610),
+      "i_G0302 + CaT_G0309"       -> Some(IPrime_CaT),
+      "z_G0304 + CaT_G0309"       -> Some(ZPrime_CaT),
+      "u_G0308"                   -> Some(UPrime)
+    )
+
+    import GmosNorthFpu._
+
+    val fpu: PioParse[Option[GmosNorthFpu]] = enum(
+      "None"                 -> Option.empty[GmosNorthFpu],
+      "Longslit 0.25 arcsec" -> Some(LongSlit_0_25),
+      "Longslit 0.50 arcsec" -> Some(LongSlit_0_50),
+      "Longslit 0.75 arcsec" -> Some(LongSlit_0_75),
+      "Longslit 1.00 arcsec" -> Some(LongSlit_1_00),
+      "Longslit 1.50 arcsec" -> Some(LongSlit_1_50),
+      "Longslit 2.00 arcsec" -> Some(LongSlit_2_00),
+      "Longslit 5.00 arcsec" -> Some(LongSlit_5_00),
+      "IFU 2 Slits"          -> Some(Ifu1),
+      "IFU Left Slit (blue)" -> Some(Ifu2),
+      "IFU Right Slit (red)" -> Some(Ifu3),
+      "N and S 0.25 arcsec"  -> Some(Ns0),
+      "N and S 0.50 arcsec"  -> Some(Ns1),
+      "N and S 0.75 arcsec"  -> Some(Ns2),
+      "N and S 1.00 arcsec"  -> Some(Ns3),
+      "N and S 1.50 arcsec"  -> Some(Ns4),
+      "N and S 2.00 arcsec"  -> Some(Ns5),
+      "Custom Mask"          -> Option.empty[GmosNorthFpu]
+    )
+
+    import GmosNorthStageMode._
+
+    val stageMode: PioParse[GmosNorthStageMode] = enum(
+      "Do Not Follow"        -> NoFollow,
+      "Follow in XYZ(focus)" -> FollowXyz,
+      "Follow in XY"         -> FollowXy,
+      "Follow in Z Only"     -> FollowZ
+    )
+  }
+
+  object GmosSouth {
+    import GmosSouthDisperser._
+
+    val disperser: PioParse[Option[GmosSouthDisperser]] = enum(
+      "Mirror"      -> Option.empty[GmosSouthDisperser],
+      "B1200_G5321" -> Some(B1200_G5321),
+      "R831_G5322"  -> Some(R831_G5322 ),
+      "B600_G5323"  -> Some(B600_G5323 ),
+      "R600_G5324"  -> Some(R600_G5324 ),
+      "R400_G5325"  -> Some(R400_G5325 ),
+      "R150_G5326"  -> Some(R150_G5326 )
+    )
+
+    import GmosSouthFilter._
+
+    val filter: PioParse[Option[GmosSouthFilter]] = enum(
+      "None"                      -> Option.empty[GmosSouthFilter],
+      "u_G0332"                   -> Some(UPrime),
+      "g_G0325"                   -> Some(GPrime),
+      "r_G0326"                   -> Some(RPrime),
+      "i_G0327"                   -> Some(IPrime),
+      "z_G0328"                   -> Some(ZPrime),
+      "Z_G0343"                   -> Some(Z),
+      "Y_G0344"                   -> Some(Y),
+      "GG455_G0329"               -> Some(GG455),
+      "OG515_G0330"               -> Some(OG515),
+      "RG610_G0331"               -> Some(RG610),
+      "RG780_G0334"               -> Some(RG780),
+      "CaT_G0333"                 -> Some(CaT),
+      "HartmannA_G0337 + r_G0326" -> Some(HartmannA_RPrime),
+      "HartmannB_G0338 + r_G0326" -> Some(HartmannB_RPrime),
+      "g_G0325 + GG455_G0329"     -> Some(GPrime_GG455),
+      "g_G0325 + OG515_G0330"     -> Some(GPrime_OG515),
+      "r_G0326 + RG610_G0331"     -> Some(RPrime_RG610),
+      "i_G0327 + RG780_G0334"     -> Some(IPrime_RG780),
+      "i_G0327 + CaT_G0333"       -> Some(IPrime_CaT),
+      "z_G0328 + CaT_G0333"       -> Some(ZPrime_CaT),
+      "Ha_G0336"                  -> Some(Ha),
+      "SII_G0335"                 -> Some(SII),
+      "HaC_G0337"                 -> Some(HaC),
+      "OIII_G0338"                -> Some(OIII),
+      "OIIIC_G0339"               -> Some(OIIIC),
+      "HeII_G0340"                -> Some(HeII),
+      "HeIIC_G0341"               -> Some(HeIIC),
+      "Lya395_G0342"              -> Some(Lya395)
+    )
+
+    import GmosSouthFpu._
+
+    val fpu: PioParse[Option[GmosSouthFpu]] = enum(
+      "None"                         -> Option.empty[GmosSouthFpu],
+      "Longslit 0.25 arcsec"         -> Some(LongSlit_0_25),
+      "Longslit 0.50 arcsec"         -> Some(LongSlit_0_50),
+      "Longslit 0.75 arcsec"         -> Some(LongSlit_0_75),
+      "Longslit 1.00 arcsec"         -> Some(LongSlit_1_00),
+      "Longslit 1.50 arcsec"         -> Some(LongSlit_1_50),
+      "Longslit 2.00 arcsec"         -> Some(LongSlit_2_00),
+      "Longslit 5.00 arcsec"         -> Some(LongSlit_5_00),
+      "IFU 2 Slits"                  -> Some(Ifu1),
+      "IFU Left Slit (blue)"         -> Some(Ifu2),
+      "IFU Right Slit (red)"         -> Some(Ifu3),
+      "bHROS"                        -> Some(Bhros),
+      "IFU N and S 2 Slits"          -> Some(IfuN),
+      "IFU N and S Left Slit (blue)" -> Some(IfuNB),
+      "IFU N and S Right Slit (red)" -> Some(IfuNR),
+      "N and S 0.50 arcsec"          -> Some(Ns1),
+      "N and S 0.75 arcsec"          -> Some(Ns2),
+      "N and S 1.00 arcsec"          -> Some(Ns3),
+      "N and S 1.50 arcsec"          -> Some(Ns4),
+      "N and S 2.00 arcsec"          -> Some(Ns5),
+      "Custom Mask"                  -> Option.empty[GmosSouthFpu]
+    )
+
+    import GmosSouthStageMode._
+
+    val stageMode: PioParse[GmosSouthStageMode] = enum(
+      "Do Not Follow"        -> NoFollow,
+      "Follow in XYZ(focus)" -> FollowXyz,
+      "Follow in XY"         -> FollowXy,
+      "Follow in Z Only"     -> FollowZ
+    )
+  }
+
+  object Gnirs {
+
+    val acquisitionMirror: PioParse[GnirsAcquisitionMirror] = {
+
+      import GnirsAcquisitionMirror._
+
+      enum(
+        "in"  -> In,
+        "out" -> Out
+      )
+    }
+
+    val camera: PioParse[GnirsCamera] = {
+
+      import GnirsCamera._
+
+      enum(
+        "short blue" -> ShortBlue,
+        "long blue"  -> LongBlue,
+        "short red"  -> ShortRed,
+        "long red"   -> LongRed
+      )
+    }
+
+    val decker: PioParse[GnirsDecker] = {
+
+      import GnirsDecker._
+
+      enum(
+        "acquisition"            -> Acquisition,
+        "pupil viewer"           -> PupilViewer,
+        "short camera long slit" -> ShortCamLongSlit,
+        "short camera x-disp"    -> ShortCamCrossDispersed,
+        "long camera x-disp"     -> LongCamCrossDispersed,
+        "IFU"                    -> Ifu,
+        "long camera long slit"  -> LongCamLongSlit,
+        "wollaston"              -> Wollaston
+      )
+
+    }
+
+    val disperser: PioParse[GnirsDisperser] = {
+
+      import GnirsDisperser._
+
+      enum(
+        "10 l/mm grating"  -> D10,
+        "32 l/mm grating"  -> D32,
+        "111 l/mm grating" -> D111
+      )
+
+    }
+
+    val filter: PioParse[GnirsFilter] = {
+
+      import GnirsFilter._
+
+      enum(
+        "x-dispersed" -> CrossDispersed,
+        "order 6 (X)" -> Order6,
+        "order 5 (J)" -> Order5,
+        "order 4 (H)" -> Order4,
+        "order 3 (K)" -> Order3,
+        "order 2 (L)" -> Order2,
+        "order 1 (M)" -> Order1,
+        "H2: 2.12um"  -> H2,
+        "H + ND100X"  -> HNd100x,
+        "H2 + ND100X" -> H2Nd100x,
+        "PAH: 3.3um"  -> PAH,
+        "Y: 1.03um"   -> Y,
+        "J: 1.25um"   -> J,
+        "K: 2.20um"   -> K
+      )
+
+    }
+
+    val fpu: PioParse[Either[GnirsFpuOther, GnirsFpuSlit]] = {
+
+      import GnirsFpuSlit._
+      import GnirsFpuOther._
+
+      enum(
+        "0.10 arcsec"  -> Right(LongSlit_0_10),
+        "0.15 arcsec"  -> Right(LongSlit_0_15),
+        "0.20 arcsec"  -> Right(LongSlit_0_20),
+        "0.30 arcsec"  -> Right(LongSlit_0_30),
+        "0.45 arcsec"  -> Right(LongSlit_0_45),
+        "0.675 arcsec" -> Right(LongSlit_0_675),
+        "1.0 arcsec"   -> Right(LongSlit_1_00),
+        "3.0 arcsec"   -> Right(LongSlit_3_00),
+        "IFU"          -> Left(Ifu),
+        "acquisition"  -> Left(Acquisition),
+        "pupil viewer" -> Left(PupilViewer),
+        "pinhole 0.1"  -> Left(Pinhole1),
+        "pinhole 0.3"  -> Left(Pinhole3)
+      )
+
+    }
+
+    val prism: PioParse[GnirsPrism] = {
+
+      import GnirsPrism._
+
+      enum(
+        "No"  -> Mirror,
+        "SXD" -> Sxd,
+        "LXD" -> Lxd
+      )
+
+    }
+
+    val readMode: PioParse[GnirsReadMode] = {
+
+      import GnirsReadMode._
+
+      enum(
+        "Very Bright/Acq./High Bckgrd." -> VeryBright,
+        "Bright Objects"                -> Bright,
+        "Faint Objects"                 -> Faint,
+        "Very Faint Objects"            -> VeryFaint
+      )
+
+    }
+
+    val centralWavelength: PioParse[Wavelength] = {
+      bigDecimal.map(w =>
+        Wavelength.fromAngstroms.unsafeGet(
+          w.underlying.movePointRight(4).intValue
+        )
+      )
+    }
+
+
+    val wellDepth: PioParse[GnirsWellDepth] = {
+
+      import GnirsWellDepth._
+
+      enum(
+        "SHALLOW" -> Shallow,
+        "DEEP"    -> Deep
+      )
+
+    }
+
+    object SmartGcal {
+
+      val mode: PioParse[GnirsAcquisitionMirror] = {
+
+        import GnirsAcquisitionMirror._
+
+        enum(
+          "IMAGING"      -> In,
+          "SPECTROSCOPY" -> Out
+        )
+
+      }
+
+      val pixelScale: PioParse[GnirsPixelScale] = {
+
+        import GnirsPixelScale._
+
+        enum(
+          "0.05\"/pix" -> PixelScale_0_05,
+          "0.15\"/pix" -> PixelScale_0_15
+        )
+
+      }
+
+    }
+
+  }
+
+  object Gpi {
+
+    val observingMode: PioParse[GpiObservingMode] = enum(
+      GpiObservingMode.all.fproduct(_.longName).map(_.swap): _*
+    )
+
+  }
+}

--- a/modules/ocs2_api/src/main/scala/gem/ocs2/pio/PioParse.scala
+++ b/modules/ocs2_api/src/main/scala/gem/ocs2/pio/PioParse.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem.ocs2.pio
+
+import gem.util.Enumerated
+import gsp.math.syntax.string._
+
+import cats.Functor
+import cats.implicits._
+import java.time.{ Duration, Instant }
+
+final case class PioParse[A](run: String => Option[A]) {
+  def apply(s: String): Option[A] = run(s)
+}
+
+object PioParse {
+
+  implicit val FunctorPioParse: Functor[PioParse] =
+    new Functor[PioParse] {
+      def map[A, B](pa: PioParse[A])(f: A => B): PioParse[B] =
+        PioParse(pa.run andThen (_.map(f)))
+    }
+
+  def enum[A](dictionary: (String, A)*): PioParse[A] =
+    PioParse(dictionary.toMap.lift)
+
+  /** Builds a PioParse for an `Enumerated` instance, assuming that the enum
+    * tags will be used as the lookup keys.  In other words, this is an option
+    * for enumerations whose OCS2 export happen to match the new model enum
+    * tags.
+    */
+  def enumFromTag[A](as: List[A])(implicit ev: Enumerated[A]): PioParse[A] =
+    PioParse(as.map(a => ev.tag(a) -> a).toMap.lift)
+
+  // ********  Primitives
+
+  val bigDecimal: PioParse[BigDecimal] =
+    PioParse(_.parseBigDecimalOption)
+
+  val boolean: PioParse[Boolean] =
+    PioParse(_.parseBooleanOption)
+
+  val double: PioParse[Double] =
+    PioParse(_.parseDoubleOption)
+
+  val short: PioParse[Short] =
+    PioParse(_.parseShortOption)
+
+  val int: PioParse[Int] =
+    PioParse(_.parseIntOption)
+
+  val positiveInt: PioParse[Int] =
+    PioParse(_.parseIntOption.filter(_ > 0))
+
+  val positiveShort: PioParse[Short] =
+    PioParse(_.parseShortOption.filter(_ > 0))
+
+  val long: PioParse[Long] =
+    PioParse(_.parseLongOption)
+
+  val string: PioParse[String] =
+    PioParse(_.pure[Option])
+
+
+  // ********  Java
+
+  val instant: PioParse[Instant] =
+    long.map(Instant.ofEpochMilli)
+
+  val seconds: PioParse[Duration] =
+    double.map { d => Duration.ofMillis((d * 1000).round) }
+}

--- a/modules/schema/src/main/resources/db/migration/V076__Giapi_StatusApply_Tolerance.sql
+++ b/modules/schema/src/main/resources/db/migration/V076__Giapi_StatusApply_Tolerance.sql
@@ -1,0 +1,9 @@
+---------------------------
+-- Giapi status apply
+---------------------------
+
+-- Add tolerance column
+ALTER TABLE e_giapi_status_apply
+    ADD COLUMN tolerance numeric(10, 4) NULL;
+
+UPDATE e_giapi_status_apply SET tolerance = 1.0 where id = 'PolarizerAngle';

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,4 @@
+// DO NOT EDIT! This file is auto-generated.
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,9 @@ resolvers += Resolver.sonatypeRepo("public")
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt"               % "6.0.0")
 addSbtPlugin("edu.gemini"            % "sbt-gsp"                  % "0.1.11")
 addSbtPlugin("com.geirsson"          % "sbt-ci-release"           % "1.4.31")
-addSbtPlugin("org.scala-js"          % "sbt-scalajs"              % "0.6.28")
+addSbtPlugin("org.scala-js"          % "sbt-scalajs"              % "0.6.31")
 addSbtPlugin("org.portable-scala"    % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("com.timushev.sbt"      % "sbt-updates"              % "0.5.0")
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql"  % "42.2.6", // needed by flyway

--- a/update.sh
+++ b/update.sh
@@ -2,6 +2,18 @@
 
 # This re-copies sources from ../ocs3
 
+echo 🔶  Setting up 'ocs2_api'
+rm -r modules/ocs2_api/*
+cp -r ../ocs3/modules/ocs2_api/src modules/ocs2_api/
+
+echo 🔶  Setting up 'ocs2'
+rm -r modules/ocs2/*
+cp -r ../ocs3/modules/ocs2/src modules/ocs2/
+
+echo 🔶  Setting up 'ephemeris'
+rm -r modules/ephemeris/*
+cp -r ../ocs3/modules/ephemeris/src modules/ephemeris/
+
 echo 🔶  Setting up 'db'
 rm -r modules/db/*
 cp -r ../ocs3/modules/db/src modules/db/


### PR DESCRIPTION
This brings gsp-core up to date with ocs3 again. It also adds the `ocs2_api`, `ocs2`, and `ephemeris` projects, which means all database knowledge is now local to this project and all we need to publish is `gso-core-model`, `gsp-core-testkit`, and `gsp-core-ocs2-api`. Everything else is built and tested to ensure that it stays up to date, but is not published.

Once this is published we can update and merge the ocs3 PR that removes core (i.e., the stuff in this repo).