### PR TITLE
[WIP] Cross compile to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,55 @@
 import sbtcrossproject.crossProject
 import sbtcrossproject.CrossType
 
-lazy val doobieVersion        = "0.6.0"
-lazy val fs2Version           = "2.2.2"
-lazy val geminiLocalesVersion = "0.2.0"
-lazy val gspMathVersion       = "0.1.10"
-lazy val kindProjectorVersion = "0.10.3"
-lazy val monocleVersion       = "2.0.1"
-lazy val paradiseVersion      = "2.1.1"
-lazy val flywayVersion        = "6.2.3"
-lazy val http4sVersion        = "0.21.0"
-lazy val scalaXmlVerson       = "1.2.0"
-lazy val mouseVersion         = "0.24"
+lazy val doobieVersion           = "0.8.6"
+lazy val fs2Version              = "2.2.2"
+lazy val geminiLocalesVersion    = "0.2.0"
+lazy val gspMathVersion          = "0.1.10+26-a6873e8c+20200215-1428-SNAPSHOT"
+lazy val kindProjectorVersion    = "0.11.0"
+lazy val monocleVersion          = "2.0.1"
+lazy val paradiseVersion         = "2.1.1"
+lazy val flywayVersion           = "6.2.3"
+lazy val http4sVersion           = "0.21.0"
+lazy val scalaXmlVerson          = "1.2.0"
+lazy val mouseVersion            = "0.24"
+
+lazy val scala212Version         = "2.12.10"
+lazy val scala213Version         = "2.13.1"
+
+lazy val silencerVersion         = "1.4.4"
+
+lazy val paradisePlugin = Def.setting {
+  PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+    case Some((2, v)) if v <= 12 =>
+      Seq(compilerPlugin("org.scalamacros" % "paradise"       % paradiseVersion cross CrossVersion.patch))
+  }.toList.flatten
+}
+
+lazy val macroAnnotations = Def.setting {
+  PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+    case Some((2, n)) if n >= 13 => Seq("-Ymacro-annotations")
+  }.toList.flatten
+}
+
+lazy val silencerPlugin = Def.setting {
+  PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+    case Some((2, v)) if v >= 13 =>
+      Seq(compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full))
+  }.toList.flatten
+}
+
+lazy val silenceDeprecations = Def.setting {
+  PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+    case Some((2, n)) if n >= 13 => Seq("-P:silencer:globalFilters=deprecated")
+  }.toList.flatten
+}
 
 inThisBuild(Seq(
   homepage := Some(url("https://github.com/gemini-hlsw/gsp-core")),
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorVersion),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorVersion cross CrossVersion.full),
   resolvers += "Gemini Repository" at "https://github.com/gemini-hlsw/maven-repo/raw/master/releases", // for gemini-locales
-  crossScalaVersions := Seq(scalaVersion.value), // for now, until we get doobie/fs2 upgraded
+  crossScalaVersions := Seq(scala212Version, scala213Version),
+  scalacOptions ++= macroAnnotations.value,
 ) ++ gspPublishSettings)
 
 // doesn't work to do this `inThisBuild`
@@ -71,8 +103,8 @@ lazy val model = crossProject(JVMPlatform, JSPlatform)
       "edu.gemini"                 %%% "gsp-math"      % gspMathVersion,
       "com.github.julien-truffaut" %%% "monocle-core"  % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-macro" % monocleVersion,
-    ),
-    addCompilerPlugin("org.scalamacros" %% "paradise" % paradiseVersion cross CrossVersion.patch),
+    ) ++ paradisePlugin.value ++ silencerPlugin.value,
+    scalacOptions ++= silenceDeprecations.value
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
   .jsSettings(gspScalaJsSettings: _*)
@@ -103,6 +135,8 @@ lazy val model_tests = crossProject(JVMPlatform, JSPlatform)
   .settings(
     skip in publish := true,
     name := "gsp-core-model-tests",
+    libraryDependencies ++= silencerPlugin.value,
+    scalacOptions in Test ++= silenceDeprecations.value
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
   .jsSettings(gspScalaJsSettings: _*)
@@ -119,7 +153,8 @@ lazy val db = project
     libraryDependencies ++= Seq(
       "org.tpolecat" %% "doobie-postgres"  % doobieVersion,
       "org.tpolecat" %% "doobie-scalatest" % doobieVersion  % "test"
-    ),
+    ) ++ silencerPlugin.value,
+    scalacOptions ++= silenceDeprecations.value,
     Test / parallelExecution := false
   )
   .enablePlugins(AutomateHeaderPlugin)
@@ -169,5 +204,6 @@ lazy val ephemeris = project
       // GspCoreTestkit.value,
       // Mouse.value,
       // Fs2IO
-    )
+    ) ++ silencerPlugin.value,
+    scalacOptions in Test ++= silenceDeprecations.value
   )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtcrossproject.CrossType
 lazy val doobieVersion           = "0.8.6"
 lazy val fs2Version              = "2.2.2"
 lazy val geminiLocalesVersion    = "0.2.0"
-lazy val gspMathVersion          = "0.1.10+26-a6873e8c+20200215-1428-SNAPSHOT"
+lazy val gspMathVersion          = "0.1.13"
 lazy val kindProjectorVersion    = "0.11.0"
 lazy val monocleVersion          = "2.0.1"
 lazy val paradiseVersion         = "2.1.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       # POSTGRES_USER: user
       # POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: gem
     ports:
       - 5432:5432

--- a/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
+++ b/modules/db/src/main/scala/gem/dao/UserTargetDao.scala
@@ -69,14 +69,14 @@ object UserTargetDao {
   /** Selects all `UserTarget`s for a program.
     */
   def selectProg(pid: Program.Id): ConnectionIO[Map[Index, TreeSet[UserTarget]]] =
-    selectProgWithId(pid).map(_.mapValues(toUserTargetSet))
+    selectProgWithId(pid).map(_.mapValues(toUserTargetSet).toMap)
 
   /** Selects all `UserTarget`s for a program paired with the `UserTarget` id
     * itself.
     */
   def selectProgWithId(pid: Program.Id): ConnectionIO[Map[Index, List[(UserTarget.Id, UserTarget)]]] =
     selectAll(Statements.selectProg(pid)).map {
-      _.groupBy(_._1).mapValues(_.unzip._2)
+      _.groupBy(_._1).mapValues(_.unzip._2).toMap
     }
 
 

--- a/modules/db/src/main/scala/gem/dao/package.scala
+++ b/modules/db/src/main/scala/gem/dao/package.scala
@@ -64,8 +64,6 @@ package object dao {
       EitherConnectionIO.right[A, T](c)
   }
 
-  /** Flattened `a` as a VALUES argument (...). */
-  def values[A](a: A)(implicit ev: Write[A]): Fragment =
-    Fragment(List.fill(ev.length)("?").mkString("(", ", ", ")"), a)
-
+  def values[A](a: A)(implicit w: Write[A]): Fragment =
+    fr"(" ++ Fragments.values(a) ++ fr")"
 }

--- a/modules/db/src/test/scala/gem/dao/check/Check.scala
+++ b/modules/db/src/test/scala/gem/dao/check/Check.scala
@@ -6,7 +6,7 @@ package check
 
 import cats.effect.{ IO, ContextShift }
 import doobie.Transactor
-import doobie.scalatest.imports._
+import doobie.scalatest._
 import gem._
 import gem.enum._
 import gem.config._

--- a/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
+++ b/modules/ephemeris/src/main/scala/gem/horizons/HorizonsEphemerisUpdater.scala
@@ -23,7 +23,7 @@ import fs2.Stream
 
 
 /** Utility for inserting / updating en ephemeris. */
-final case class HorizonsEphemerisUpdater[M[_]: Monad: LiftIO](xa: Transactor[M]) {
+final case class HorizonsEphemerisUpdater[M[_] : LiftIO](xa: Transactor[M])(implicit bracket: Bracket[M, Throwable]) {
 
   import HorizonsEphemerisUpdater._
 

--- a/modules/gen/src/main/scala/gem/sql/enum/GpiEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GpiEnums.scala
@@ -20,7 +20,7 @@ object GpiEnums {
       },
 
       EnumDef.fromQuery("GpiFilter", "GPI Filter") {
-        val  m = Witness('MagnitudeBand)
+        val  m = Witness(Symbol("MagnitudeBand"))
         type M = m.T
         type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'band -> EnumRef[M], 'obsolete -> Boolean`.T
         val ret = sql"""SELECT id, id tag, short_name, long_name, band, obsolete FROM e_gpi_filter""".query[(String, E)]
@@ -88,7 +88,7 @@ object GpiEnums {
       },
 
       EnumDef.fromQuery("GpiObservingMode", "GPI ObservingMode") {
-        val (a, b, c, d, e) = (Witness('GpiFilter), Witness('GpiApodizer), Witness('GpiFPM), Witness('GpiLyot), Witness('GpiObservingMode))
+        val (a, b, c, d, e) = (Witness(Symbol("GpiFilter")), Witness(Symbol("GpiApodizer")), Witness(Symbol("GpiFPM")), Witness(Symbol("GpiLyot")), Witness(Symbol("GpiObservingMode")))
         type A = a.T
         type B = b.T
         type C = c.T

--- a/modules/gen/src/main/scala/gem/sql/enum/GsaoiEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GsaoiEnums.scala
@@ -21,8 +21,8 @@ object GsaoiEnums {
       },
 
       EnumDef.fromQuery("GsaoiFilter", "GSAOI Filter") {
-        val  m = Witness('MagnitudeBand)
-        val  r = Witness('GsaoiReadMode)
+        val  m = Witness(Symbol("MagnitudeBand"))
+        val  r = Witness(Symbol("GsaoiReadMode"))
         type M = m.T
         type R = r.T
         type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um, 'readMode -> EnumRef[R], 'exposureTime5050 -> FiniteDuration.Seconds, 'exposureTimeHalfWell -> FiniteDuration.Seconds, 'band -> Option[EnumRef[M]]`.T

--- a/modules/gen/src/main/scala/gem/sql/enum/MiscEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/MiscEnums.scala
@@ -103,7 +103,7 @@ object MiscEnums {
       },
 
       EnumDef.fromQuery("GiapiStatusApply", "Giapi Status Apply") {
-        val (a, b) = (Witness('Instrument), Witness('GiapiType))
+        val (a, b) = (Witness(Symbol("Instrument")), Witness(Symbol("GiapiType")))
         type A = a.T
         type B = b.T
         type R = Record.`'tag -> String, 'instrument -> EnumRef[A], 'statusType -> EnumRef[B], 'statusItem -> String, 'applyItem -> String, 'tolerance -> Option[BigDecimal]`.T
@@ -112,7 +112,7 @@ object MiscEnums {
       },
 
       EnumDef.fromQuery("GiapiStatus", "Giapi Status") {
-        val (a, b) = (Witness('Instrument), Witness('GiapiType))
+        val (a, b) = (Witness(Symbol("Instrument")), Witness(Symbol("GiapiType")))
         type A = a.T
         type B = b.T
         type R = Record.`'tag -> String, 'instrument -> EnumRef[A], 'statusType -> EnumRef[B], 'statusItem -> String`.T

--- a/modules/model/shared/src/main/scala/gem/util/Enumerated.scala
+++ b/modules/model/shared/src/main/scala/gem/util/Enumerated.scala
@@ -29,7 +29,7 @@ trait Enumerated[A] extends Order[A] {
 
   // Hashed index lookup, for efficient use as an `Order`.
   private lazy val indexOfTag: Map[String, Int] =
-    all.zipWithIndex.map { case (a, n) => (tag(a), n) } (collection.breakOut)
+    all.zipWithIndex.view.map { case (a, n) => (tag(a), n) }.toMap
 
 }
 

--- a/modules/model/shared/src/main/scala/gem/util/Enumerated.scala
+++ b/modules/model/shared/src/main/scala/gem/util/Enumerated.scala
@@ -29,7 +29,7 @@ trait Enumerated[A] extends Order[A] {
 
   // Hashed index lookup, for efficient use as an `Order`.
   private lazy val indexOfTag: Map[String, Int] =
-    all.zipWithIndex.view.map { case (a, n) => (tag(a), n) }.toMap
+    all.zipWithIndex.iterator.map { case (a, n) => (tag(a), n) }.toMap
 
 }
 

--- a/modules/model/shared/src/main/scala/gem/util/Location.scala
+++ b/modules/model/shared/src/main/scala/gem/util/Location.scala
@@ -6,6 +6,7 @@ package gem.util
 import cats._, cats.data._, cats.implicits._
 import scala.BigDecimal.RoundingMode.FLOOR
 import scala.annotation.tailrec
+import java.math.MathContext
 
 /** A sortable value used to indicate relative positions of a set of associated
   * elements.  `Location`s may be thought of as lists of arbitrary integers
@@ -168,13 +169,13 @@ object Location {
       if (gapSize < BigDecimal.exact(1)) go(len + 1)
       else {
         // This is the existing start position as a BigDecimal.
-        val startBd = BigDecimal(start10, 0)
+        val startBd = BigDecimal(start10, 0, MathContext.UNLIMITED)
 
         // Calculate count digits separated one from the other by gapSized gaps,
         // but rounding down to make them integral. Since gapSize is at least
         // 1.0, this will always advance and never produce duplicates.
         (1 to count)
-          .view
+          .iterator
           .scanLeft(startBd) { (sum, _) => sum + gapSize }
           .drop(1)          
           .map { bd => fromBase10(bd.setScale(0, FLOOR).toBigInt) }

--- a/modules/model/shared/src/main/scala/gem/util/Location.scala
+++ b/modules/model/shared/src/main/scala/gem/util/Location.scala
@@ -6,7 +6,6 @@ package gem.util
 import cats._, cats.data._, cats.implicits._
 import scala.BigDecimal.RoundingMode.FLOOR
 import scala.annotation.tailrec
-import scala.collection.breakOut
 
 /** A sortable value used to indicate relative positions of a set of associated
   * elements.  `Location`s may be thought of as lists of arbitrary integers
@@ -17,7 +16,6 @@ import scala.collection.breakOut
   * @group Sequence Model
   */
 sealed trait Location extends Product with Serializable {
-
   // These functions aren't of any use to clients.  Instead they are involved
   // in the cacluation of Locations that fall between two other locations.
 
@@ -176,9 +174,11 @@ object Location {
         // but rounding down to make them integral. Since gapSize is at least
         // 1.0, this will always advance and never produce duplicates.
         (1 to count)
+          .view
           .scanLeft(startBd) { (sum, _) => sum + gapSize }
-          .drop(1)
-          .map { bd => fromBase10(bd.setScale(0, FLOOR).toBigInt) }(breakOut)
+          .drop(1)          
+          .map { bd => fromBase10(bd.setScale(0, FLOOR).toBigInt) }
+          .toList
       }
     }
 


### PR DESCRIPTION
It's mostly working but I'm going to need a bit of help here due to my lack of knowledge of the domain and `doobie`.

Here's a summary of changes:
- Symbol syntax.
- Upgraded `doobie` to `0.8.6`, the highest I could manage to go. `0.8.7+` complains about missing `Get`s/`Put`s.
- There's no more `breakOut`for collections.
  - I tried [scala-collection-compat](https://github.com/scala/scala-collection-compat), but this causes an unused import warning on 2.13 (https://github.com/scala/scala-collection-compat/issues/240).
  - So, I decided to go with `Views` to replace them, but I'm not 100% this works as desired on Scala 2.12
- There were a number of `deprecated` warnings, mostly involving `scala.collection.immutable.Stream`. I'm not sure how to best proceed with these.
  - If we use a compatibility layer, we have the same problem as with collections regarding unused imports.
  - For the moment, I'm using [silencer](https://github.com/ghik/silencer) to mute the deprecation warnings only in the projects that require it.
- There is a failing test only in 2.13, for `Location.find`. Please see inline comment.