### PR TITLE
Updated to use gsp-sbt, requires changing Symbols

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,15 +14,17 @@ jobs:
           java-version: 1.8
       - name: Build the docker-compose stack
         run: docker-compose up -d
-      - name: Cache Coursier
+      - name: Cache dependencies
         uses: actions/cache@v1
         with:
-          path: ~/.cache/coursier
-          key: sbt-coursier-cache
-      - name: Cache SBT
+          path: ~/.cache/coursier/v1
+          key: ${{ runner.os }}-coursier-${{ hashFiles('build.sbt') }}-${{ hashFiles('project/*.scala') }}
+          restore-keys: ${{ runner.os }}-coursier-
+      - name: Cache .sbt
         uses: actions/cache@v1
         with:
           path: ~/.sbt
-          key: sbt-${{ hashFiles('**/build.sbt') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}-${{ hashFiles('project/*.scala') }}
+          restore-keys: ${{ runner.os }}-sbt-
       - name: Run compile
-        run: csbt headerCheck +compile +test
+        run: csbt headerCheck +compile +test rebuildEnums

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val gspMathVersion          = "0.1.17"
 lazy val kindProjectorVersion    = "0.11.0"
 lazy val monocleVersion          = "2.0.4"
 lazy val paradiseVersion         = "2.1.1"
-lazy val flywayVersion           = "6.4.0"
+lazy val flywayVersion           = "6.4.1"
 lazy val http4sVersion           = "0.21.3"
 lazy val scalaXmlVerson          = "1.3.0"
 lazy val mouseVersion            = "0.25"
@@ -19,7 +19,6 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 inThisBuild(Seq(
   homepage := Some(url("https://github.com/gemini-hlsw/gsp-core")),
   addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorVersion cross CrossVersion.full),
-  resolvers += "Gemini Repository" at "https://github.com/gemini-hlsw/maven-repo/raw/master/releases", // for gemini-locales
   scalacOptions += "-Ymacro-annotations",
 ) ++ gspPublishSettings)
 

--- a/modules/gen/src/main/scala/gem/sql/enum/F2Enums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/F2Enums.scala
@@ -14,32 +14,32 @@ object F2Enums {
     List(
 
       EnumDef.fromQuery("F2Disperser", "Flamingos2 dispersers") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("wavelength")-> Wavelength.Um`.T
         sql"SELECT id, id tag, short_name, long_name, wavelength FROM e_f2_disperser".query[(String, R)]
       },
 
       EnumDef.fromQuery("F2Filter", "Flamingos2 filters") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Option[Wavelength.Um], 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("wavelength")-> Option[Wavelength.Um], Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, wavelength, obsolete FROM e_f2_filter".query[(String, R)]
       },
 
       EnumDef.fromQuery("F2Fpu", "Flamingos2 focal plane units") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Int, 'decker -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("slitWidth")-> Int, Symbol("decker")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, slit_width, decker, obsolete FROM e_f2_fpu".query[(String, R)]
       },
 
       EnumDef.fromQuery("F2LyotWheel", "Flamingos2 Lyot wheel") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'plateScale -> Double, 'pixelScale -> Double, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("plateScale")-> Double, Symbol("pixelScale")-> Double, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, plate_scale, pixel_scale, obsolete FROM e_f2_lyot_wheel".query[(String, R)]
       },
 
       EnumDef.fromQuery("F2ReadMode", "Flamingos2 read modes") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'description -> String, 'minimumExposureTime -> FiniteDuration.Seconds, 'recommendedExposureTime -> FiniteDuration.Seconds, 'readoutTime -> FiniteDuration.Seconds, 'readCount -> Int, 'readNoise -> Double`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("description")-> String, Symbol("minimumExposureTime")-> FiniteDuration.Seconds, Symbol("recommendedExposureTime")-> FiniteDuration.Seconds, Symbol("readoutTime")-> FiniteDuration.Seconds, Symbol("readCount")-> Int, Symbol("readNoise")-> Double`.T
         sql"SELECT id, id tag, short_name, long_name, description, minimum_exposure_time, recommended_exposure_time, readout_time, read_count, read_noise FROM e_f2_read_mode".query[(String, R)]
       },
 
       EnumDef.fromQuery("F2WindowCover", "Flamingos2 window cover state") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"SELECT id, id tag, short_name, long_name FROM e_f2_window_cover".query[(String, R)]
       }
 

--- a/modules/gen/src/main/scala/gem/sql/enum/GcalEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GcalEnums.scala
@@ -13,32 +13,32 @@ object GcalEnums {
     List(
 
       EnumDef.fromQuery("GcalFilter", "calibration unit filter") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_filter".query[(String, R)]
       },
 
       EnumDef.fromQuery("GcalContinuum", "calibration unit continuum lamps") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_continuum".query[(String, R)]
       },
 
       EnumDef.fromQuery("GcalArc", "calibration unit arc lamps") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_arc".query[(String, R)]
       },
 
       EnumDef.fromQuery("GcalDiffuser", "calibration unit diffusers") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_diffuser".query[(String, R)]
       },
 
       EnumDef.fromQuery("GcalShutter", "calibration unit shutter states") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_gcal_shutter".query[(String, R)]
       },
 
       EnumDef.fromQuery("GcalBaselineType", "calibration baseline type") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -47,7 +47,7 @@ object GcalEnums {
       },
 
       EnumDef.fromQuery("GcalLampType", "calibration lamp type") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -56,7 +56,7 @@ object GcalEnums {
       },
 
       EnumDef.fromQuery("SmartGcalType", "\"smart\" calibration sequence tpes") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid

--- a/modules/gen/src/main/scala/gem/sql/enum/GmosEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GmosEnums.scala
@@ -14,102 +14,102 @@ object GmosEnums {
     List(
 
       EnumDef.fromQuery("GmosAdc", "GMOS ADC") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_adc""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosAmpCount", "GMOS amp count") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_amp_count""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosAmpGain", "GMOS amp gain") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_amp_gain""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosAmpReadMode", "GMOS amp read mode") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gmos_amp_read_mode""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosCustomSlitWidth", "GMOS custom slit width") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'width -> Arcseconds`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("width")-> Arcseconds`.T
         sql"""SELECT id, id tag, short_name, long_name, width FROM e_gmos_custom_slit_width""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosDetector", "GMOS detector") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'northPixelSize -> Arcseconds, 'southPixelSize -> Arcseconds, 'shuffleOffset -> Int, 'xSize -> Int, 'ySize -> Int, 'maxRois -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("northPixelSize")-> Arcseconds, Symbol("southPixelSize")-> Arcseconds, Symbol("shuffleOffset")-> Int, Symbol("xSize")-> Int, Symbol("ySize")-> Int, Symbol("maxRois")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, north_pixel_size, south_pixel_size, shuffle_offset, x_size, y_size, max_rois FROM e_gmos_detector""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosDisperserOrder", "GMOS disperser order") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("count")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, count FROM e_gmos_disperser_order""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosDtax", "GMOS detector translation X offset") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'dtax -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("dtax")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, dtax FROM e_gmos_dtax""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosEOffsetting", "GMOS Electric Offsetting") {
-        type R = Record.`'tag -> String, 'description -> String, 'toBoolean -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("description")-> String, Symbol("toBoolean")-> Boolean`.T
         sql"select id, id tag, description, to_boolean FROM e_gmos_e_offsetting".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosNorthDisperser", "GMOS North dispersers") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'rulingDensity -> Int, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("rulingDensity")-> Int, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, ruling_density, obsolete FROM e_gmos_north_disperser""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosNorthFilter", "GMOS North filters") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("wavelength")-> Wavelength.Um, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, wavelength, obsolete FROM e_gmos_north_filter""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosNorthFpu", "GMOS North focal plane units") {
-        type GmosNorthFpuRec = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Option[Arcseconds]`.T
+        type GmosNorthFpuRec = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("slitWidth")-> Option[Arcseconds]`.T
         sql"""SELECT id, id tag, short_name, long_name, slit_width FROM e_gmos_north_fpu""".query[(String, GmosNorthFpuRec)]
       },
 
       EnumDef.fromQuery("GmosNorthStageMode", "GMOS North stage modes") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gmos_north_stage_mode""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosRoi", "GMOS ROI (region of interest)") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gmos_roi""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosSouthDisperser", "GMOS South dispersers") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'rulingDensity -> Int, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("rulingDensity")-> Int, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, ruling_density, obsolete FROM e_gmos_south_disperser""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosSouthFilter", "GMOS South filters") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("wavelength")-> Wavelength.Um, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, wavelength, obsolete FROM e_gmos_south_filter""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosSouthFpu", "GMOS South focal plane units") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Option[Arcseconds]`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("slitWidth")-> Option[Arcseconds]`.T
         sql"""SELECT id, id tag, short_name, long_name, slit_width FROM e_gmos_south_fpu""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosSouthStageMode", "GMOS South stage mode") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gmos_south_stage_mode""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosXBinning", "GMOS X-binning") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("count")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, count FROM e_gmos_binning""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GmosYBinning", "GMOS Y-binning") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("count")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, count FROM e_gmos_binning""".query[(String, R)]
       }
 

--- a/modules/gen/src/main/scala/gem/sql/enum/GnirsEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GnirsEnums.scala
@@ -14,53 +14,53 @@ object GnirsEnums {
     List(
 
       EnumDef.fromQuery("GnirsAcquisitionMirror", "GNIRS Acquisition Mirror") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gnirs_acquisition_mirror""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsCamera", "GNIRS Camera") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'pixelScale -> GnirsPixelScale`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("pixelScale")-> GnirsPixelScale`.T
         sql"""SELECT id, id tag, short_name, long_name, pixel_scale FROM e_gnirs_camera""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsDecker", "GNRIS Decker") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gnirs_decker""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsDisperser", "GNIRS Disperser") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'rulingDensity -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("rulingDensity")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, ruling_density FROM e_gnirs_disperser""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsDisperserOrder", "GNIRS Disperser Order") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'count -> Int, 'defaultWavelength -> Wavelength.Um, 'minWavelength -> Wavelength.Um, 'maxWavelength -> Wavelength.Um, 'deltaWavelength -> Wavelength.Um, 'band -> Option[MagnitudeBand], 'cross_dispersed -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("count")-> Int, Symbol("defaultWavelength")-> Wavelength.Um, Symbol("minWavelength")-> Wavelength.Um, Symbol("maxWavelength")-> Wavelength.Um, Symbol("deltaWavelength")-> Wavelength.Um, Symbol("band")-> Option[MagnitudeBand], Symbol("cross_dispersed")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, count, default_wavelength, min_wavelength, max_wavelength, delta_wavelength, band, cross_dispersed FROM e_gnirs_disperser_order""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsFilter", "GNIRS Filter") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'waveLength -> Option[Wavelength.Um]`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("waveLength")-> Option[Wavelength.Um]`.T
         sql"""SELECT id, id tag, short_name, long_name, wavelength FROM e_gnirs_filter""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsFpuSlit", "GNIRS FPU Slit") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'slitWidth -> Arcseconds, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("slitWidth")-> Arcseconds, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, slit_width, obsolete FROM e_gnirs_fpu_slit""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsFpuOther", "GNIRS FPU Other") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gnirs_fpu_other""".query[(String, R)]
       },
 
       EnumDef.fromQuery("GnirsPixelScale", "GNIRS Pixel Scale") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> BigDecimal`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> BigDecimal`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gnirs_pixel_scale""".query[(String, R)]
       },
 
 
       EnumDef.fromQuery("GnirsWellDepth", "GNRIS Well Depth") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'bias_level -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("bias_level")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, bias_level FROM e_gnirs_well_depth""".query[(String, R)]
       }
 

--- a/modules/gen/src/main/scala/gem/sql/enum/GpiEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GpiEnums.scala
@@ -15,75 +15,75 @@ object GpiEnums {
     List(
 
       EnumDef.fromQuery("GpiAdc", "GPI ADC") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_adc""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiFilter", "GPI Filter") {
         val  m = Witness(Symbol("MagnitudeBand"))
         type M = m.T
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'band -> EnumRef[M], 'obsolete -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("band")-> EnumRef[M], Symbol("obsolete")-> Boolean`.T
         val ret = sql"""SELECT id, id tag, short_name, long_name, band, obsolete FROM e_gpi_filter""".query[(String, E)]
         (ret, m.value: M)._1 // convince scalac that we really do use M
       },
 
       EnumDef.fromQuery("GpiDisperser", "GPI Disperser") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gpi_disperser""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiApodizer", "GPI Apodizer") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_apodizer""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiLyot", "GPI Lyot") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_lyot""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiASU", "GPI Artificial Source Unit") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_artificial_source_unit""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiEntranceShutter", "GPI Entrance Shutter") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_entrance_shutter""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiScienceArmShutter", "GPI Science Arm Shutter") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_sience_arm_shutter""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiCalEntranceShutter", "GPI Cal Entrance Shutter") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_cal_entrance_shutter""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiReferenceArmShutter", "GPI Reference Arm Shutter") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_reference_arm_shutter""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiPupilCamera", "GPI Pupil Camera") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_pupil_camera""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiFPM", "GPI FPM") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_fpm""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiSamplingMode", "GPI Sampling Mode") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"""SELECT id, id tag, short_name, long_name, obsolete FROM e_gpi_sampling_mode""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GpiCassegrain", "GPI Cassegrain") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'value -> Int`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("value")-> Int`.T
         sql"""SELECT id, id tag, short_name, long_name, value FROM e_gpi_cassegrain""".query[(String, E)]
       },
 
@@ -94,13 +94,13 @@ object GpiEnums {
         type C = c.T
         type D = d.T
         type E = e.T
-        type F = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'filter -> Option[EnumRef[A]], 'filterIterable -> Boolean, 'apodizer -> Option[EnumRef[B]], 'fpm -> Option[EnumRef[C]], 'lyot -> Option[EnumRef[D]], 'brightLimitPrism -> Option[MagnitudeValue], 'brightLimitWollaston -> Option[MagnitudeValue], 'correspondingHMode -> LazyEnumRef[E], 'obsolete  -> Boolean`.T
+        type F = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("filter")-> Option[EnumRef[A]], Symbol("filterIterable")-> Boolean, Symbol("apodizer")-> Option[EnumRef[B]], Symbol("fpm")-> Option[EnumRef[C]], Symbol("lyot")-> Option[EnumRef[D]], Symbol("brightLimitPrism")-> Option[MagnitudeValue], Symbol("brightLimitWollaston")-> Option[MagnitudeValue], Symbol("correspondingHMode")-> LazyEnumRef[E], Symbol("obsolete") -> Boolean`.T
         val ret = sql"""SELECT id, id tag, short_name, long_name, filter, filter_iterable, apodizer, fpm, lyot, bright_limit_prism, bright_limit_wollaston, corresponding_h_mode, obsolete FROM e_gpi_observing_mode""".query[(String, F)]
         (ret, a.value: A, b.value: B, c.value: C, d.value: D, e.value: E)._1 // suppress unused warnigs
       },
 
       EnumDef.fromQuery("GpiReadMode", "GPI ReadMode") {
-        type E = Record.`'tag -> String, 'longName -> String, 'value -> Int`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("longName")-> String, Symbol("value")-> Int`.T
         sql"""SELECT id, id tag, long_name, value FROM e_gpi_read_mode""".query[(String, E)]
       }
 

--- a/modules/gen/src/main/scala/gem/sql/enum/GsaoiEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/GsaoiEnums.scala
@@ -16,7 +16,7 @@ object GsaoiEnums {
     List(
 
       EnumDef.fromQuery("GsaoiReadMode", "GSAOI Read Mode") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'ndr -> Int, 'readNoise -> Int, 'minimumExposureTime -> FiniteDuration.Seconds, 'overhead -> FiniteDuration.Seconds`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("ndr")-> Int, Symbol("readNoise")-> Int, Symbol("minimumExposureTime")-> FiniteDuration.Seconds, Symbol("overhead")-> FiniteDuration.Seconds`.T
         sql"""SELECT id, id tag, short_name, long_name, ndr, read_noise, minimum_exposure_time, overhead FROM e_gsaoi_read_mode""".query[(String, E)]
       },
 
@@ -25,23 +25,23 @@ object GsaoiEnums {
         val  r = Witness(Symbol("GsaoiReadMode"))
         type M = m.T
         type R = r.T
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'wavelength -> Wavelength.Um, 'readMode -> EnumRef[R], 'exposureTime5050 -> FiniteDuration.Seconds, 'exposureTimeHalfWell -> FiniteDuration.Seconds, 'band -> Option[EnumRef[M]]`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("wavelength")-> Wavelength.Um, Symbol("readMode")-> EnumRef[R], Symbol("exposureTime5050")-> FiniteDuration.Seconds, Symbol("exposureTimeHalfWell")-> FiniteDuration.Seconds, Symbol("band")-> Option[EnumRef[M]]`.T
         val ret = sql"""SELECT id, id tag, short_name, long_name, wavelength, read_mode_id, exposure_time_50_50, exposure_time_half_well, band_id FROM e_gsaoi_filter""".query[(String, E)]
         (ret, m.value: M, r.value: R)._1 // convince scalac that we really do use M and R
       },
 
       EnumDef.fromQuery("GsaoiUtilityWheel", "Gsaoi Utility Wheel") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gsaoi_utility_wheel""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GsaoiRoi", "Gsaoi Region of Interest") {
-        type E = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"""SELECT id, id tag, short_name, long_name FROM e_gsaoi_roi""".query[(String, E)]
       },
 
       EnumDef.fromQuery("GsaoiOdgwSize", "Gsaoi ODGW Size") {
-        type E = Record.`'tag -> String, 'pixels -> Int`.T
+        type E = Record.`Symbol("tag")-> String, Symbol("pixels")-> Int`.T
         sql"""SELECT id, id tag, pixels FROM e_gsaoi_odgw_pixels""".query[(String, E)]
       }
     )

--- a/modules/gen/src/main/scala/gem/sql/enum/MiscEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/MiscEnums.scala
@@ -20,12 +20,12 @@ object MiscEnums {
     List(
 
       EnumDef.fromQuery("MosPreImaging", "MOS pre-imaging category") {
-        type R = Record.`'tag -> String, 'description -> String, 'toBoolean -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("description")-> String, Symbol("toBoolean")-> Boolean`.T
         sql"SELECT id, id tag, description, to_boolean FROM e_mos_preimaging".query[(String, R)]
       },
 
       EnumDef.fromQuery("StepType", "step types") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -34,7 +34,7 @@ object MiscEnums {
       },
 
       EnumDef.fromQuery("EventType", "observe [[gem.Event Event]]) types") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel a, enumlabel b
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -43,29 +43,29 @@ object MiscEnums {
       },
 
       EnumDef.fromQuery("Instrument", "instruments") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_instrument".query[(String, R)]
       },
 
       EnumDef.fromQuery("ProgramType", "program types (see [[gem.ProgramId ProgramId]])") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_program_type".query[(String, R)]
       },
 
       EnumDef.fromQuery("Site", "Gemini observing sites") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'mountain -> String, 'latitude -> Degrees, 'longitude -> Degrees, 'altitude -> Int, 'timezone -> ZoneId`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("mountain")-> String, Symbol("latitude")-> Degrees, Symbol("longitude")-> Degrees, Symbol("altitude")-> Int, Symbol("timezone")-> ZoneId`.T
         sql"""SELECT id, id tag, short_name, long_name, mountain, latitude, longitude, altitude,
                 timezone
               FROM e_site""".query[(String, R)]
       },
 
       EnumDef.fromQuery("ProgramRole", "user roles with respect to a given program") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"SELECT id, id tag, short_name, long_name FROM e_program_role".query[(String, R)]
       },
 
       EnumDef.fromQuery("Half", "semester half") {
-        type R = Record.`'tag -> String, 'toInt -> Int`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("toInt")-> Int`.T
         sql"""
           SELECT enumlabel x, enumlabel y, enumsortorder - 1
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -74,27 +74,27 @@ object MiscEnums {
       },
 
       EnumDef.fromQuery("EphemerisKeyType", "Non-sidereal target lookup type") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String`.T
         sql"SELECT id, id tag, short_name, long_name FROM e_ephemeris_type".query[(String, R)]
       },
 
       EnumDef.fromQuery("KeywordName", "Fits Keyword names") {
-        type R = Record.`'tag -> String, 'name -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("name")-> String`.T
         sql"SELECT id, id tag, name FROM e_fits_keyword_names".query[(String, R)]
       },
 
       EnumDef.fromQuery("DhsKeywordName", "DHS Keyword names") {
-        type R = Record.`'tag -> String, 'keyword -> KeywordName, 'name -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("keyword")-> KeywordName, Symbol("name")-> String`.T
         sql"SELECT keyword, keyword tag, keyword tag, name FROM e_dhs_keyword_names".query[(String, R)]
       },
 
       EnumDef.fromQuery("LightSinkName", "SF Sink names") {
-        type R = Record.`'tag -> String, 'name -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("name")-> String`.T
         sql"SELECT id, id tag, name FROM e_light_sink_names".query[(String, R)]
       },
 
       EnumDef.fromQuery("GiapiType", "giapi status types") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -106,7 +106,7 @@ object MiscEnums {
         val (a, b) = (Witness(Symbol("Instrument")), Witness(Symbol("GiapiType")))
         type A = a.T
         type B = b.T
-        type R = Record.`'tag -> String, 'instrument -> EnumRef[A], 'statusType -> EnumRef[B], 'statusItem -> String, 'applyItem -> String, 'tolerance -> Option[BigDecimal]`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("instrument")-> EnumRef[A], Symbol("statusType")-> EnumRef[B], Symbol("statusItem")-> String, Symbol("applyItem")-> String, Symbol("tolerance")-> Option[BigDecimal]`.T
         val ret = sql"SELECT concat(instrument_id, id), concat(instrument_id, id) tag, instrument_id, type, status_item, apply_item, tolerance FROM e_giapi_status_apply".query[(String, R)]
         (ret, a.value: A, b.value: B)._1 // suppress unused warnigs
       },
@@ -115,7 +115,7 @@ object MiscEnums {
         val (a, b) = (Witness(Symbol("Instrument")), Witness(Symbol("GiapiType")))
         type A = a.T
         type B = b.T
-        type R = Record.`'tag -> String, 'instrument -> EnumRef[A], 'statusType -> EnumRef[B], 'statusItem -> String`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("instrument")-> EnumRef[A], Symbol("statusType")-> EnumRef[B], Symbol("statusItem")-> String`.T
         val ret = sql"SELECT concat(instrument_id, id), concat(instrument_id, id) tag, instrument_id, type, status_item FROM e_giapi_status".query[(String, R)]
         (ret, a.value: A, b.value: B)._1 // suppress unused warnigs
       }

--- a/modules/gen/src/main/scala/gem/sql/enum/TargetEnums.scala
+++ b/modules/gen/src/main/scala/gem/sql/enum/TargetEnums.scala
@@ -13,7 +13,7 @@ object TargetEnums {
     List(
 
       EnumDef.fromQuery("AsterismType", "asterism types") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -22,7 +22,7 @@ object TargetEnums {
       },
 
       EnumDef.fromQuery("TrackType", "track types") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -31,7 +31,7 @@ object TargetEnums {
       },
 
       EnumDef.fromQuery("MagnitudeSystem", "magnitude system") {
-        type R = Record.`'tag -> String`.T
+        type R = Record.`Symbol("tag")-> String`.T
         sql"""
           SELECT enumlabel x, enumlabel y
           FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
@@ -40,12 +40,12 @@ object TargetEnums {
       },
 
       EnumDef.fromQuery("MagnitudeBand", "magnitude band") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'center -> Wavelength.Nm, 'width -> Int, 'magnitudeSystem -> MagnitudeSystem`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("center")-> Wavelength.Nm, Symbol("width")-> Int, Symbol("magnitudeSystem")-> MagnitudeSystem`.T
         sql"""SELECT id, id tag, short_name, long_name, center, width, default_system FROM e_magnitude_band""".query[(String, R)]
       },
 
       EnumDef.fromQuery("UserTargetType", "user target type") {
-        type R = Record.`'tag -> String, 'shortName -> String, 'longName -> String, 'obsolete -> Boolean`.T
+        type R = Record.`Symbol("tag")-> String, Symbol("shortName")-> String, Symbol("longName")-> String, Symbol("obsolete")-> Boolean`.T
         sql"SELECT id, id tag, short_name, long_name, obsolete FROM e_user_target_type".query[(String, R)]
       }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.sonatypeRepo("public")
 
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt"               % "6.4.0")
-addSbtPlugin("edu.gemini"            % "sbt-gsp"                  % "0.1.14")
+addSbtPlugin("edu.gemini"            % "sbt-gsp"                  % "0.1.17")
 addSbtPlugin("com.geirsson"          % "sbt-ci-release"           % "1.5.3")
 addSbtPlugin("org.scala-js"          % "sbt-scalajs"              % "0.6.32")
 addSbtPlugin("org.portable-scala"    % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
Updates sbt-gsp and pulls scala 2.13.2 in the process. This requires replacing the deprecated `Symbol` style to use the explicit version