### PR TITLE
Add Magnitude class

### DIFF
--- a/modules/model-tests/shared/src/test/scala/gem/MagnitudeSpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/MagnitudeSpec.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+import gem.arb._
+
+final class MagnitudeSpec extends CatsSuite {
+  import ArbMagnitude._
+
+  // Laws
+  checkAll("Eq[Magnitude]",           EqTests[Magnitude].eqv)
+  checkAll("MagnitudeOrdering",       OrderTests[Magnitude](Magnitude.MagnitudeOrdering).order)
+  checkAll("MagnitudeOptionOrdering", OrderTests[Option[Magnitude]](Magnitude.MagnitudeOptionOrdering).order)
+}

--- a/modules/model-tests/shared/src/test/scala/gem/MagnitudeSpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/MagnitudeSpec.scala
@@ -11,7 +11,6 @@ final class MagnitudeSpec extends CatsSuite {
   import ArbMagnitude._
 
   // Laws
-  checkAll("Eq[Magnitude]",           EqTests[Magnitude].eqv)
-  checkAll("MagnitudeOrdering",       OrderTests[Magnitude](Magnitude.MagnitudeOrdering).order)
-  checkAll("MagnitudeOptionOrdering", OrderTests[Option[Magnitude]](Magnitude.MagnitudeOptionOrdering).order)
+  checkAll("Magnitude",         EqTests[Magnitude].eqv)
+  checkAll("MagnitudeOrdering", OrderTests[Magnitude](Magnitude.MagnitudeOrdering).order)
 }

--- a/modules/model/shared/src/main/scala/gem/Magnitude.scala
+++ b/modules/model/shared/src/main/scala/gem/Magnitude.scala
@@ -14,12 +14,17 @@ import monocle.macros.Lenses
  * Describes the magnitude of a target on a given band
  */
 @Lenses
-case class Magnitude(
+final case class Magnitude(
   value: MagnitudeValue,
   band: MagnitudeBand,
   error: Option[MagnitudeValue],
   system: MagnitudeSystem
-)
+) {
+  override def toString: String = {
+    val errStr = error.map { e => f"${e.toDoubleValue}%.2f" }
+    f"Magnitude(${value.toDoubleValue}%.2f, ${band.shortName}, $errStr, ${system.tag})"
+  }
+}
 
 object Magnitude {
   /** Secondary constructor. */
@@ -38,33 +43,9 @@ object Magnitude {
   implicit val MagnitudeOrdering: Order[Magnitude] =
     Order.by(m => (m.system.tag, m.band.tag, m.value, m.error))
 
-  private def compareOptionWith(
-    x: Option[Magnitude],
-    y: Option[Magnitude],
-    c: Order[Magnitude]
-  ): Int =
-    (x,y) match {
-      case (Some(m1), Some(m2)) => c.compare(m1, m2)
-      case (None,     None)     =>  0
-      case (_,        None)     => -1
-      case (None,     _)        =>  1
-    }
-
-  // comparison on Option[Magnitude] that reverses the way that None is treated, i.e. None is always > Some(Magnitude).
-  implicit val MagnitudeOptionOrdering: Order[Option[Magnitude]] =
-    new Order[Option[Magnitude]] {
-      override def compare(x: Option[Magnitude], y: Option[Magnitude]): Int =
-        compareOptionWith(x, y, MagnitudeOrdering)
-    }
-
-  /** @group Typeclass Instances */
-  implicit val EqMagnitude: Eq[Magnitude] = Eq.by(x => (x.value, x.band, x.error, x.system))
-
   /** group Typeclass Instances */
   implicit val MagnitudeShow: Show[Magnitude] =
-    Show.show { mag =>
-      val errStr = mag.error.map { e => f" e${e.toDoubleValue}%.2f " }.getOrElse(" ")
-      f"${mag.band.shortName}${mag.value.toDoubleValue}%.2f$errStr(${mag.system.tag})"
-    }
+    Show.fromToString
+
 }
 

--- a/modules/model/shared/src/main/scala/gem/Magnitude.scala
+++ b/modules/model/shared/src/main/scala/gem/Magnitude.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import cats.implicits._
+import gem.enum.MagnitudeBand
+import gem.enum.MagnitudeSystem
+import gsp.math.MagnitudeValue
+import monocle.macros.Lenses
+
+/**
+ * Describes the magnitude of a target on a given band
+ */
+@Lenses
+case class Magnitude(
+  value: MagnitudeValue,
+  band: MagnitudeBand,
+  error: Option[MagnitudeValue],
+  system: MagnitudeSystem
+)
+
+object Magnitude {
+  /** Secondary constructor. */
+  def apply(value: MagnitudeValue, band: MagnitudeBand, error: MagnitudeValue) =
+    new Magnitude(value, band, Some(error), band.magnitudeSystem)
+
+  /** Secondary constructor defaulting to no error. */
+  def apply(value: MagnitudeValue, band: MagnitudeBand, system: MagnitudeSystem) =
+    new Magnitude(value, band, None, system)
+
+  /** Secondary constructor defaulting to no given error. */
+  def apply(value: MagnitudeValue, band: MagnitudeBand) =
+    new Magnitude(value, band, None, band.magnitudeSystem)
+
+  // by system name, band name, value and error (in that order)
+  implicit val MagnitudeOrdering: Order[Magnitude] =
+    Order.by(m => (m.system.tag, m.band.tag, m.value, m.error))
+
+  private def compareOptionWith(
+    x: Option[Magnitude],
+    y: Option[Magnitude],
+    c: Order[Magnitude]
+  ): Int =
+    (x,y) match {
+      case (Some(m1), Some(m2)) => c.compare(m1, m2)
+      case (None,     None)     =>  0
+      case (_,        None)     => -1
+      case (None,     _)        =>  1
+    }
+
+  // comparison on Option[Magnitude] that reverses the way that None is treated, i.e. None is always > Some(Magnitude).
+  implicit val MagnitudeOptionOrdering: Order[Option[Magnitude]] =
+    new Order[Option[Magnitude]] {
+      override def compare(x: Option[Magnitude], y: Option[Magnitude]): Int =
+        compareOptionWith(x, y, MagnitudeOrdering)
+    }
+
+  /** @group Typeclass Instances */
+  implicit val EqMagnitude: Eq[Magnitude] = Eq.by(x => (x.value, x.band, x.error, x.system))
+
+  /** group Typeclass Instances */
+  implicit val MagnitudeShow: Show[Magnitude] =
+    Show.show { mag =>
+      val errStr = mag.error.map { e => f" e${e.toDoubleValue}%.2f " }.getOrElse(" ")
+      f"${mag.band.shortName}${mag.value.toDoubleValue}%.2f$errStr(${mag.system.tag})"
+    }
+}
+

--- a/modules/model/shared/src/main/scala/gem/config/GmosConfig.scala
+++ b/modules/model/shared/src/main/scala/gem/config/GmosConfig.scala
@@ -403,7 +403,7 @@ object GmosConfig {
     val maskDefinitionFilename: Lens[GmosCustomMask, String] =
       Lens[GmosCustomMask, String](_.maskDefinitionFilename)(a => _.copy(maskDefinitionFilename = a))
 
-    /** @gropu Optics */
+    /** @group Optics */
     val slitWidth: Lens[GmosCustomMask, GmosCustomSlitWidth] =
       Lens[GmosCustomMask, GmosCustomSlitWidth](_.slitWidth)(a => _.copy(slitWidth = a))
 

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbMagnitude.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbMagnitude.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+package arb
+
+import gem.enum.MagnitudeBand
+import gem.enum.MagnitudeSystem
+import gsp.math.arb.ArbMagnitudeValue._
+import gsp.math.MagnitudeValue
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen._
+
+trait ArbMagnitude {
+
+  import ArbEnumerated._
+
+  implicit val arbMagnitude: Arbitrary[Magnitude] =
+    Arbitrary {
+      for {
+        v <- arbitrary[MagnitudeValue]
+        b <- arbitrary[MagnitudeBand]
+        e <- arbitrary[Option[MagnitudeValue]]
+        s <- arbitrary[MagnitudeSystem]
+      } yield Magnitude(v, b, e, s)
+    }
+
+  implicit val cogMagnitude: Cogen[Magnitude] =
+    Cogen[(MagnitudeValue, MagnitudeBand, Option[MagnitudeValue], MagnitudeSystem)].contramap { u =>
+      (u.value, u.band, u.error, u.system)
+    }
+}
+
+object ArbMagnitude extends ArbMagnitude


### PR DESCRIPTION
This is a Magnitude class very much based on the one from ocs.

A question for @tpolecat and @swalker2m. I wanted to add right away a list of `Magnitude` to `Target` but it requires me to develop DAOs and importers from ocs2. Are we still planning to use those?