### PR TITLE
Zipper.findFocus on right when focus not on head.

### DIFF
--- a/modules/util/src/main/scala/gpp/util/Zipper.scala
+++ b/modules/util/src/main/scala/gpp/util/Zipper.scala
@@ -58,7 +58,7 @@ final case class Zipper[A] private (lefts: List[A], focus: A, rights: List[A]) {
       else
         (rights.splitAt(indexRight) match {
           case (x, h :: t) =>
-            Zipper(lefts ::: (focus :: x).reverse, h, t)
+            Zipper((focus :: x).reverse ::: lefts, h, t)
           case _           =>
             this
         }).some
@@ -103,6 +103,12 @@ object Zipper {
     */
   def fromNel[A](ne: NonEmptyList[A]): Zipper[A] =
     Zipper(Nil, ne.head, ne.tail)
+
+  /**
+    * Builds a Zipper from elements. The first element becomes the focus
+    */
+  def of[A](a: A, as: A*): Zipper[A] =
+    Zipper(Nil, a, as.toList)
 
   /**
     * @typeclass Eq

--- a/modules/util/src/test/scala/gpp/util/ZipperSpec.scala
+++ b/modules/util/src/test/scala/gpp/util/ZipperSpec.scala
@@ -56,6 +56,11 @@ final class ZipperSpec extends CatsSuite {
         assert(l.next.flatMap(_.previous) === l.some)
     }
   }
+  test("of") {
+    forAll { (nel: NonEmptyList[Int]) =>
+      assert(Zipper.of(nel.head, nel.tail:_*) === Zipper.fromNel(nel))
+    }
+  }  
   test("toNel") {
     forAll { (nel: NonEmptyList[Int]) =>
       assert(Zipper.fromNel(nel).toNel === nel)
@@ -95,17 +100,19 @@ final class ZipperSpec extends CatsSuite {
     assert(z1.flatMap(_.findFocus(_ === 2)).exists(_.rights === List(3, 4, 5, 6)))
   }
   test("find focus on rights") {
-    val z1 = Zipper.fromNel(NonEmptyList(0, List(1, 2, 3, 4, 5, 6)))
-    assert(z1.findFocus(_ === 0).exists(_.focus === 0))
-    assert(z1.findFocus(_ === 0).exists(_.lefts.isEmpty))
-    assert(z1.findFocus(_ === 0).exists(_.rights === List(1, 2, 3, 4, 5, 6)))
-    assert(z1.findFocus(_ === 1).exists(_.focus === 1))
-    assert(z1.findFocus(_ === 1).exists(_.lefts === List(0)))
-    assert(z1.findFocus(_ === 1).exists(_.rights === List(2, 3, 4, 5, 6)))
-    assert(z1.findFocus(_ === 4).exists(_.focus === 4))
-    assert(z1.findFocus(_ === 4).exists(_.lefts === List(3, 2, 1, 0)))
-    assert(z1.findFocus(_ === 4).exists(_.rights === List(5, 6)))
-  }
+    // move three positions to the right
+    val z1 =
+      Zipper.fromNel(NonEmptyList(0, List(1, 2, 3, 4, 5, 6))).next.flatMap(_.next).flatMap(_.next)
+    assert(z1.flatMap(_.findFocus(_ === 4)).exists(_.focus === 4))
+    assert(z1.flatMap(_.findFocus(_ === 4)).exists(_.lefts === List(3, 2, 1, 0)))
+    assert(z1.flatMap(_.findFocus(_ === 4)).exists(_.rights == List(5, 6)))
+    assert(z1.flatMap(_.findFocus(_ === 5)).exists(_.focus === 5))
+    assert(z1.flatMap(_.findFocus(_ === 5)).exists(_.lefts === List(4, 3, 2, 1, 0)))
+    assert(z1.flatMap(_.findFocus(_ === 5)).exists(_.rights === List(6)))
+    assert(z1.flatMap(_.findFocus(_ === 6)).exists(_.focus === 6))
+    assert(z1.flatMap(_.findFocus(_ === 6)).exists(_.lefts === List(5, 4, 3, 2, 1, 0)))
+    assert(z1.flatMap(_.findFocus(_ === 6)).exists(_.rights.isEmpty))
+  }  
   test("support find focus I") {
     forAll { (r: List[Int]) =>
       val u = Zipper.fromNel(NonEmptyList(0, 1 :: r))


### PR DESCRIPTION
`Zipper.findFocus` resulting left list had elements exchanged when the original `Zipper` didn't have focus on the first element and the found element was on its right list.