### PR TITLE
EnumZipper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,7 @@ lazy val util = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("modules/util"))
   .settings(commonSettings)
+  .dependsOn(model)
   .settings(
     name := "gpp-core-util",
     libraryDependencies ++= Seq(

--- a/modules/util/src/main/scala/gpp/util/EnumZipper.scala
+++ b/modules/util/src/main/scala/gpp/util/EnumZipper.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gpp.util
+
+import cats.kernel.Eq
+import cats.implicits._
+import gem.util.Enumerated
+
+class EnumZipper[A](lefts: List[A], focus: A, rights: List[A])
+  extends Zipper[A](lefts: List[A], focus: A, rights: List[A])
+  with ZipperOps[A, EnumZipper[A]] {
+
+  override def build(lefts: List[A], focus: A, rights: List[A]): EnumZipper[A] =
+    EnumZipper.build(lefts, focus, rights)
+
+  override def unmodified: EnumZipper[A] = this
+
+  def focusIn(a: A)(implicit eq: Eq[A]): EnumZipper[A] =
+    if (focus === a) unmodified
+    else {
+      val indexLeft  = lefts.lastIndexWhere(_ === a)
+      if (indexLeft >= 0)
+        (lefts.splitAt(indexLeft) match {
+          case (x, i :: l) =>
+            build(l, i, (focus :: x).reverse ::: rights)
+          case _           =>
+            unmodified
+        })
+      else
+        (rights.splitAt(rights.indexWhere(_ === a)) match {
+          case (x, h :: t) =>
+            build((focus :: x).reverse ::: lefts, h, t)
+          case _           =>
+            unmodified
+        })
+    }
+}
+
+object EnumZipper extends ZipperFactory[EnumZipper] {
+
+  /**
+    * Builds an EnumZipper from an Enumerated. The first element becomes the focus.
+    */
+  def of[A](implicit e: Enumerated[A]): EnumZipper[A] = 
+    build(Nil, e.all.head, e.all.tail)
+
+  override protected def build[A](lefts: List[A], focus: A, rights: List[A]): EnumZipper[A] = 
+    new EnumZipper(lefts, focus, rights)
+
+}

--- a/modules/util/src/main/scala/gpp/util/EnumZipper.scala
+++ b/modules/util/src/main/scala/gpp/util/EnumZipper.scala
@@ -16,7 +16,7 @@ class EnumZipper[A](lefts: List[A], focus: A, rights: List[A])
 
   override def unmodified: EnumZipper[A] = this
 
-  def focusIn(a: A)(implicit eq: Eq[A]): EnumZipper[A] =
+  def withFocus(a: A)(implicit eq: Eq[A]): EnumZipper[A] =
     if (focus === a) unmodified
     else {
       val indexLeft  = lefts.lastIndexWhere(_ === a)

--- a/modules/util/src/main/scala/gpp/util/ZipperFactory.scala
+++ b/modules/util/src/main/scala/gpp/util/ZipperFactory.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gpp.util
+
+import cats._
+import cats.implicits._
+import cats.data.NonEmptyList
+import monocle.{ Lens, Prism, Traversal }
+
+protected[util] trait ZipperFactory[Z[A] <: ZipperOps[A, Zipper[A]]] {
+
+  protected def build[A](lefts: List[A], focus: A, rights: List[A]): Z[A]
+
+  /**
+    * @typeclass Eq
+    */
+  implicit def equal[A: Eq]: Eq[Z[A]] =
+    Eq.instance { (a, b) =>
+      a.focus === b.focus && a.lefts === b.lefts && a.rights === b.rights
+    }
+
+  /**
+    * @typeclass Traverse
+    * Based on traverse implementation for List
+    */
+  implicit val traverse: Traverse[Z] = new Traverse[Z] {
+    override def traverse[G[_], A, B](
+      fa: Z[A]
+    )(f:  A => G[B])(implicit G: Applicative[G]): G[Z[B]] =
+      (fa.lefts.traverse(f), f(fa.focus), fa.rights.traverse(f)).mapN {
+        case (l, f, r) => build(l, f, r)
+      }
+
+    override def foldLeft[A, B](fa: Z[A], b: B)(f: (B, A) => B): B =
+      fa.toNel.foldLeft(b)(f)
+
+    override def foldRight[A, B](fa: Z[A], lb: Eval[B])(
+      f:                             (A, Eval[B]) => Eval[B]
+    ): Eval[B] = {
+      def loop(as: Vector[A]): Eval[B] =
+        as match {
+          case h +: t => f(h, Eval.defer(loop(t)))
+          case _      => lb
+        }
+
+      Eval.defer(loop(fa.toList.toVector))
+    }
+  }
+
+  def lefts[A]: Lens[Z[A], List[A]] = Lens[Z[A], List[A]](_.lefts)(v => z => build(v, z.focus, z.rights))
+  def focus[A]: Lens[Z[A], A] = Lens[Z[A], A](_.focus)(v => z => build(z.lefts, v, z.rights))
+  def rights[A]: Lens[Z[A], List[A]] = Lens[Z[A], List[A]](_.rights)(v => z => build(z.lefts, z.focus, v))
+
+  /**
+    * Creates a monocle Traversal for the Zipper
+    */
+  def zipperT[A]: Traversal[Z[A], A] =
+    Traversal.fromTraverse
+
+  /**
+    * Traversal filtered zipper, Note this is unsafe as the predicate breaks some laws
+    */
+  def unsafeSelect[A](predicate: A => Boolean): Traversal[Z[A], A] =
+    new Traversal[Z[A], A] {
+      override def modifyF[F[_]: Applicative](f: A => F[A])(s: Z[A]): F[Z[A]] = {
+        val lefts: F[List[A]]  = s.lefts.traverse {
+          case x if predicate(x) => f(x)
+          case x                 => x.pure[F]
+        }
+        val rights: F[List[A]] = s.rights.traverse {
+          case x if predicate(x) => f(x)
+          case x                 => x.pure[F]
+        }
+        val focus: F[A]        =
+          if (predicate(s.focus)) f(s.focus) else s.focus.pure[F]
+        (lefts, focus, rights).mapN { (l, f, r) =>
+          build(l, f, r)
+        }
+      }
+    }
+}

--- a/modules/util/src/test/scala/gpp/util/EnumZipperSpec.scala
+++ b/modules/util/src/test/scala/gpp/util/EnumZipperSpec.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gpp.util
+
+import cats.tests.CatsSuite
+import gem.enum.StepType
+import gem.enum.StepType._
+
+final class EnumZipperSpec extends CatsSuite {
+  test("focusIn on focus") {
+    // move two positions to the right
+    val z1 = EnumZipper.of[StepType].next.flatMap(_.next)
+    assert(z1.map(_.focusIn(Gcal)).exists(_.focus === Gcal))
+    assert(z1.map(_.focusIn(Gcal)).exists(_.lefts === List(Dark, Bias)))
+    assert(z1.map(_.focusIn(Gcal)).exists(_.rights == List(Science, SmartGcal)))
+  }
+  test("focusIn on left") {
+    // move two positions to the right
+    val z1 = EnumZipper.of[StepType].next.flatMap(_.next)
+    assert(z1.map(_.focusIn(Bias)).exists(_.focus === Bias))
+    assert(z1.map(_.focusIn(Bias)).exists(_.lefts.isEmpty))
+    assert(z1.map(_.focusIn(Bias)).exists(_.rights == List(Dark, Gcal, Science, SmartGcal)))
+    assert(z1.map(_.focusIn(Dark)).exists(_.focus === Dark))
+    assert(z1.map(_.focusIn(Dark)).exists(_.lefts === List(Bias)))
+    assert(z1.map(_.focusIn(Dark)).exists(_.rights == List(Gcal, Science, SmartGcal)))
+  }
+  test("focusIn on right") {
+    // move two positions to the right
+    val z1 = EnumZipper.of[StepType].next.flatMap(_.next)
+    assert(z1.map(_.focusIn(Science)).exists(_.focus === Science))
+    assert(z1.map(_.focusIn(Science)).exists(_.lefts === List(Gcal, Dark, Bias)))
+    assert(z1.map(_.focusIn(Science)).exists(_.rights == List(SmartGcal)))
+    assert(z1.map(_.focusIn(SmartGcal)).exists(_.focus === SmartGcal))
+    assert(z1.map(_.focusIn(SmartGcal)).exists(_.lefts === List(Science, Gcal, Dark, Bias)))
+    assert(z1.map(_.focusIn(SmartGcal)).exists(_.rights.isEmpty))
+  }
+}

--- a/modules/util/src/test/scala/gpp/util/EnumZipperSpec.scala
+++ b/modules/util/src/test/scala/gpp/util/EnumZipperSpec.scala
@@ -8,31 +8,31 @@ import gem.enum.StepType
 import gem.enum.StepType._
 
 final class EnumZipperSpec extends CatsSuite {
-  test("focusIn on focus") {
+  test("withFocus on focus") {
     // move two positions to the right
     val z1 = EnumZipper.of[StepType].next.flatMap(_.next)
-    assert(z1.map(_.focusIn(Gcal)).exists(_.focus === Gcal))
-    assert(z1.map(_.focusIn(Gcal)).exists(_.lefts === List(Dark, Bias)))
-    assert(z1.map(_.focusIn(Gcal)).exists(_.rights == List(Science, SmartGcal)))
+    assert(z1.map(_.withFocus(Gcal)).exists(_.focus === Gcal))
+    assert(z1.map(_.withFocus(Gcal)).exists(_.lefts === List(Dark, Bias)))
+    assert(z1.map(_.withFocus(Gcal)).exists(_.rights == List(Science, SmartGcal)))
   }
-  test("focusIn on left") {
+  test("withFocus on left") {
     // move two positions to the right
     val z1 = EnumZipper.of[StepType].next.flatMap(_.next)
-    assert(z1.map(_.focusIn(Bias)).exists(_.focus === Bias))
-    assert(z1.map(_.focusIn(Bias)).exists(_.lefts.isEmpty))
-    assert(z1.map(_.focusIn(Bias)).exists(_.rights == List(Dark, Gcal, Science, SmartGcal)))
-    assert(z1.map(_.focusIn(Dark)).exists(_.focus === Dark))
-    assert(z1.map(_.focusIn(Dark)).exists(_.lefts === List(Bias)))
-    assert(z1.map(_.focusIn(Dark)).exists(_.rights == List(Gcal, Science, SmartGcal)))
+    assert(z1.map(_.withFocus(Bias)).exists(_.focus === Bias))
+    assert(z1.map(_.withFocus(Bias)).exists(_.lefts.isEmpty))
+    assert(z1.map(_.withFocus(Bias)).exists(_.rights == List(Dark, Gcal, Science, SmartGcal)))
+    assert(z1.map(_.withFocus(Dark)).exists(_.focus === Dark))
+    assert(z1.map(_.withFocus(Dark)).exists(_.lefts === List(Bias)))
+    assert(z1.map(_.withFocus(Dark)).exists(_.rights == List(Gcal, Science, SmartGcal)))
   }
-  test("focusIn on right") {
+  test("withFocus on right") {
     // move two positions to the right
     val z1 = EnumZipper.of[StepType].next.flatMap(_.next)
-    assert(z1.map(_.focusIn(Science)).exists(_.focus === Science))
-    assert(z1.map(_.focusIn(Science)).exists(_.lefts === List(Gcal, Dark, Bias)))
-    assert(z1.map(_.focusIn(Science)).exists(_.rights == List(SmartGcal)))
-    assert(z1.map(_.focusIn(SmartGcal)).exists(_.focus === SmartGcal))
-    assert(z1.map(_.focusIn(SmartGcal)).exists(_.lefts === List(Science, Gcal, Dark, Bias)))
-    assert(z1.map(_.focusIn(SmartGcal)).exists(_.rights.isEmpty))
+    assert(z1.map(_.withFocus(Science)).exists(_.focus === Science))
+    assert(z1.map(_.withFocus(Science)).exists(_.lefts === List(Gcal, Dark, Bias)))
+    assert(z1.map(_.withFocus(Science)).exists(_.rights == List(SmartGcal)))
+    assert(z1.map(_.withFocus(SmartGcal)).exists(_.focus === SmartGcal))
+    assert(z1.map(_.withFocus(SmartGcal)).exists(_.lefts === List(Science, Gcal, Dark, Bias)))
+    assert(z1.map(_.withFocus(SmartGcal)).exists(_.rights.isEmpty))
   }
 }

--- a/modules/util/src/test/scala/gpp/util/ZipperSpec.scala
+++ b/modules/util/src/test/scala/gpp/util/ZipperSpec.scala
@@ -85,6 +85,14 @@ final class ZipperSpec extends CatsSuite {
       assert(e.isDefined)
     }
   }
+  test("find focus on focus") {
+    // move three positions to the right
+    val z1 =
+      Zipper.fromNel(NonEmptyList(0, List(1, 2, 3, 4, 5, 6))).next.flatMap(_.next).flatMap(_.next)
+    assert(z1.flatMap(_.findFocus(_ === 3)).exists(_.focus === 3))
+    assert(z1.flatMap(_.findFocus(_ === 3)).exists(_.lefts === List(2, 1, 0)))
+    assert(z1.flatMap(_.findFocus(_ === 3)).exists(_.rights == List(4, 5, 6)))
+  }
   test("find focus on lefts") {
     // move three positions to the right
     val z1 =


### PR DESCRIPTION
An `EnumZipper` is a `Zipper`, but can only be constructed by using `EnumZipper.of[A : Enumerated]`.

It adds a method `.focusIn(a)` which is guaranteed to succeed, so it returns an `EnumZipper[A]` (in contrast to `.findFocus` which returns an `Option[Zipper[A]]`).