### PR TITLE
Redshift/RadialVelocity/ApparentRadialVelocity

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val http4sVersion               = "0.21.6"
 lazy val scalaXmlVerson              = "1.3.0"
 lazy val mouseVersion                = "0.25"
 lazy val silencerVersion             = "1.6.0"
-lazy val coulombVersion              = "0.5.0-RC2"
+lazy val coulombVersion              = "0.5.0"
 lazy val spireVersion                = "0.17.0-RC1"
 lazy val singletonOpsVersion         = "0.5.0"
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,12 +87,10 @@ lazy val model = crossProject(JVMPlatform, JSPlatform)
       "edu.gemini"                 %%% "gsp-math"           % gspMathVersion,
       "com.github.julien-truffaut" %%% "monocle-core"       % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-macro"      % monocleVersion,
-      "com.manyangled"             %%% "coulomb"            % coulombVersion, // The seven SI units: meter, second, kilogram, etc
-      "com.manyangled"             %%% "coulomb-si-units"   % coulombVersion, // The seven SI units: meter, second, kilogram, etc
-      "com.manyangled"             %%% "coulomb-time-units" % coulombVersion, // minute, hour, day, week
-      "com.manyangled"             %%% "coulomb-temp-units" % coulombVersion, // Celsius and Fahrenheit temperature scales
-      "org.typelevel"              %%% "spire"              % "0.17.0-RC1",
-      "eu.timepit"                 %%% "singleton-ops"      % "0.5.0"
+      "com.manyangled"             %%% "coulomb"            % coulombVersion,
+      "com.manyangled"             %%% "coulomb-si-units"   % coulombVersion,
+      "org.typelevel"              %%% "spire"              % spireVersion,
+      "eu.timepit"                 %%% "singleton-ops"      % singletonOpsVersion
     )
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,9 @@ lazy val http4sVersion               = "0.21.6"
 lazy val scalaXmlVerson              = "1.3.0"
 lazy val mouseVersion                = "0.25"
 lazy val silencerVersion             = "1.6.0"
+lazy val coulombVersion              = "0.4.7-SNAPSHOT"
+lazy val spireVersion                = "0.17.0-RC1"
+lazy val singletonOpsVersion         = "0.5.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -80,10 +83,16 @@ lazy val model = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "gsp-core-model",
     libraryDependencies ++= Seq(
-      "co.fs2"                     %%% "fs2-core"      % fs2Version,
-      "edu.gemini"                 %%% "gsp-math"      % gspMathVersion,
-      "com.github.julien-truffaut" %%% "monocle-core"  % monocleVersion,
-      "com.github.julien-truffaut" %%% "monocle-macro" % monocleVersion
+      "co.fs2"                     %%% "fs2-core"           % fs2Version,
+      "edu.gemini"                 %%% "gsp-math"           % gspMathVersion,
+      "com.github.julien-truffaut" %%% "monocle-core"       % monocleVersion,
+      "com.github.julien-truffaut" %%% "monocle-macro"      % monocleVersion,
+      "com.manyangled"             %%% "coulomb"            % coulombVersion, // The seven SI units: meter, second, kilogram, etc
+      "com.manyangled"             %%% "coulomb-si-units"   % coulombVersion, // The seven SI units: meter, second, kilogram, etc
+      "com.manyangled"             %%% "coulomb-time-units" % coulombVersion, // minute, hour, day, week
+      "com.manyangled"             %%% "coulomb-temp-units" % coulombVersion, // Celsius and Fahrenheit temperature scales
+      "org.typelevel"              %%% "spire"              % "0.17.0-RC1",
+      "eu.timepit"                 %%% "singleton-ops"      % "0.5.0"
     )
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))

--- a/build.sbt
+++ b/build.sbt
@@ -15,13 +15,11 @@ lazy val http4sVersion               = "0.21.6"
 lazy val scalaXmlVerson              = "1.3.0"
 lazy val mouseVersion                = "0.25"
 lazy val silencerVersion             = "1.6.0"
-lazy val coulombVersion              = "0.5.0-RC1"
+lazy val coulombVersion              = "0.5.0-RC2"
 lazy val spireVersion                = "0.17.0-RC1"
 lazy val singletonOpsVersion         = "0.5.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
-
-Global / resolvers += "manyangled" at "https://dl.bintray.com/manyangled/maven/"
 
 inThisBuild(
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,13 @@ lazy val http4sVersion               = "0.21.6"
 lazy val scalaXmlVerson              = "1.3.0"
 lazy val mouseVersion                = "0.25"
 lazy val silencerVersion             = "1.6.0"
-lazy val coulombVersion              = "0.4.7-SNAPSHOT"
+lazy val coulombVersion              = "0.5.0-RC1"
 lazy val spireVersion                = "0.17.0-RC1"
 lazy val singletonOpsVersion         = "0.5.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
+
+Global / resolvers += "manyangled" at "https://dl.bintray.com/manyangled/maven/"
 
 inThisBuild(
   Seq(

--- a/modules/model-tests/shared/src/test/scala/gem/ApparentRadialVelocitySpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/ApparentRadialVelocitySpec.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import gem.arb._
+import java.math.MathContext
+
+final class ApparentRadialVelocitySpec extends CatsSuite {
+  import ArbApparentRadialVelocity._
+
+  // Laws
+  checkAll("ApparentRadialVelocity", EqTests[ApparentRadialVelocity].eqv)
+  checkAll("ApparentRadialVelocityOrder", OrderTests[ApparentRadialVelocity].order)
+
+  test("toRedshift") {
+    assert(
+      // Note the speed is given in Meter per second but coulomb will convert
+      ApparentRadialVelocity(0.withUnit[Meter %/ Second]).toRedshift === Redshift.Zero
+    )
+    assert(ApparentRadialVelocity(RadialVelocity.C).toRedshift === Redshift(1))
+    assert(
+      ApparentRadialVelocity(
+        BigDecimal.decimal(1000, MathContext.DECIMAL32).withUnit[(Kilo %* Meter) %/ Second]
+      ).toRedshift ===
+        Redshift(BigDecimal.decimal(0.003335641, MathContext.DECIMAL32))
+    )
+  }
+}

--- a/modules/model-tests/shared/src/test/scala/gem/RadialVelocitySpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/RadialVelocitySpec.scala
@@ -25,7 +25,6 @@ final class RadialVelocitySpec extends CatsSuite {
         .flatMap(_.toRedshift)
         .exists(_ === Redshift.Zero)
     )
-    assert(RadialVelocity.CRadialVelocity.toRedshift.isEmpty)
     assert(
       RadialVelocity(1000.withUnit[(Kilo %* Meter) %/ Second])
         .flatMap(_.toRedshift)

--- a/modules/model-tests/shared/src/test/scala/gem/RadialVelocitySpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/RadialVelocitySpec.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import gem.arb._
+
+final class RadialVelocitySpec extends CatsSuite {
+  import ArbRadialVelocity._
+
+  // Laws
+  checkAll("RadialVelocity", EqTests[RadialVelocity].eqv)
+  checkAll("RadialVelocityOrder", OrderTests[RadialVelocity].order)
+
+  test("toRedshift") {
+    assert(
+      // Note the speed is given in Meter per second but coulomb will convert
+      RadialVelocity(0.withUnit[Meter %/ Second])
+        .flatMap(_.toRedshift)
+        .exists(_ === Redshift.Zero)
+    )
+    assert(RadialVelocity.CRadialVelocity.toRedshift.isEmpty)
+    assert(
+      RadialVelocity(1000.withUnit[(Kilo %* Meter) %/ Second])
+        .flatMap(_.toRedshift)
+        .exists(_ === Redshift(0.003341222805847144))
+    )
+  }
+}

--- a/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
@@ -8,6 +8,8 @@ import cats.kernel.laws.discipline._
 
 import coulomb._
 import coulomb.si._
+import coulomb.siprefix._
+import java.math.MathContext
 import gem.arb._
 
 final class RedshiftSpec extends CatsSuite {
@@ -17,11 +19,16 @@ final class RedshiftSpec extends CatsSuite {
   checkAll("Redshift", EqTests[Redshift].eqv)
   checkAll("RedshiftOrder", OrderTests[Redshift].order)
 
-  test("fromVelocity") {
-    assert(Redshift.Zero.some === Redshift.fromVelocity(0.withUnit[Meter %/ Second]))
-    assert(Redshift.fromVelocity(Redshift.C).isEmpty)
+  test("toRadialVelocity") {
+    assert(Redshift.Zero.toRadialVelocity === RadialVelocity(0.withUnit[Meter %/ Second]))
     assert(
-      Redshift(3.335641007851109e-8).some === Redshift.fromVelocity(10.withUnit[Meter %/ Second])
+      // Example from http://spiff.rit.edu/classes/phys240/lectures/expand/expand.html
+      // We need to specify the Math context to properly compale
+      Redshift(BigDecimal.decimal(5.82, MathContext.DECIMAL32)).toRadialVelocity === RadialVelocity(
+        BigDecimal
+          .decimal(287172.912028, MathContext.DECIMAL32)
+          .withUnit[(Kilo %* Meter) %/ Second]
+      )
     )
   }
 }

--- a/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
@@ -23,10 +23,27 @@ final class RedshiftSpec extends CatsSuite {
     assert(Redshift.Zero.toRadialVelocity === RadialVelocity(0.withUnit[Meter %/ Second]))
     assert(
       // Example from http://spiff.rit.edu/classes/phys240/lectures/expand/expand.html
-      // We need to specify the Math context to properly compale
+      // We need to specify the Math context to properly compare
       Redshift(BigDecimal.decimal(5.82, MathContext.DECIMAL32)).toRadialVelocity === RadialVelocity(
         BigDecimal
           .decimal(287172.912028, MathContext.DECIMAL32)
+          .withUnit[(Kilo %* Meter) %/ Second]
+      )
+    )
+  }
+
+  test("toApparentRadialVelocity") {
+    assert(
+      Redshift.Zero.toApparentRadialVelocity === ApparentRadialVelocity(0.withUnit[Meter %/ Second])
+    )
+    assert(Redshift(1).toApparentRadialVelocity === ApparentRadialVelocity(RadialVelocity.C))
+    assert(
+      // In apparent radial velocity we can go faster than C
+      Redshift(
+        BigDecimal.decimal(5.82, MathContext.DECIMAL64)
+      ).toApparentRadialVelocity === ApparentRadialVelocity(
+        BigDecimal
+          .decimal(1744792.10556, MathContext.DECIMAL64)
           .withUnit[(Kilo %* Meter) %/ Second]
       )
     )

--- a/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
@@ -24,9 +24,9 @@ final class RedshiftSpec extends CatsSuite {
     assert(
       // Example from http://spiff.rit.edu/classes/phys240/lectures/expand/expand.html
       // We need to specify the Math context to properly compare
-      Redshift(BigDecimal.decimal(5.82, MathContext.DECIMAL32)).toRadialVelocity === RadialVelocity(
+      Redshift(BigDecimal.decimal(5.82, MathContext.DECIMAL64)).toRadialVelocity === RadialVelocity(
         BigDecimal
-          .decimal(287172.912028, MathContext.DECIMAL32)
+          .decimal(287172.9120288430, MathContext.DECIMAL64)
           .withUnit[(Kilo %* Meter) %/ Second]
       )
     )

--- a/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
+++ b/modules/model-tests/shared/src/test/scala/gem/RedshiftSpec.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats.tests.CatsSuite
+import cats.kernel.laws.discipline._
+
+import coulomb._
+import coulomb.si._
+import gem.arb._
+
+final class RedshiftSpec extends CatsSuite {
+  import ArbRedshift._
+
+  // Laws
+  checkAll("Redshift", EqTests[Redshift].eqv)
+  checkAll("RedshiftOrder", OrderTests[Redshift].order)
+
+  test("fromVelocity") {
+    assert(Redshift.Zero.some === Redshift.fromVelocity(0.withUnit[Meter %/ Second]))
+    assert(Redshift.fromVelocity(Redshift.C).isEmpty)
+    assert(
+      Redshift(3.335641007851109e-8).some === Redshift.fromVelocity(10.withUnit[Meter %/ Second])
+    )
+  }
+}

--- a/modules/model/shared/src/main/scala/gem/ApparentRadialVelocity.scala
+++ b/modules/model/shared/src/main/scala/gem/ApparentRadialVelocity.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import coulomb._
+// import coulomb.si._
+// import coulomb.siprefix._
+import spire.std.bigDecimal._
+
+/**
+  * Representation of a radial velocity in kilometers per second
+  * Unlike RadialVelocity this is not limited to the speed of light
+  * This is often represented as cz
+  */
+final case class ApparentRadialVelocity(cz: RadialVelocity.RVQuantity) {
+
+  /**
+    * Converts the apparent radial velocity to a Redshift, approximate
+    */
+  def toRedshift: Redshift = Redshift((cz / RadialVelocity.C).value)
+}
+
+object ApparentRadialVelocity {
+
+  /**
+    * `No ApparentRadialVelocity`
+    * @group Constructors
+    */
+  val Zero: ApparentRadialVelocity = new ApparentRadialVelocity(0.withUnit[RadialVelocity.RVUnit])
+
+  /** @group Typeclass Instances */
+  implicit val order: Order[ApparentRadialVelocity] =
+    Order.by(_.cz.value)
+
+}

--- a/modules/model/shared/src/main/scala/gem/ApparentRadialVelocity.scala
+++ b/modules/model/shared/src/main/scala/gem/ApparentRadialVelocity.scala
@@ -5,19 +5,17 @@ package gem
 
 import cats._
 import coulomb._
-// import coulomb.si._
-// import coulomb.siprefix._
 import spire.std.bigDecimal._
 
 /**
   * Representation of a radial velocity in kilometers per second
   * Unlike RadialVelocity this is not limited to the speed of light
-  * This is often represented as cz
+  * Apparent Radial Velocity is often represented as cz
   */
 final case class ApparentRadialVelocity(cz: RadialVelocity.RVQuantity) {
 
   /**
-    * Converts the apparent radial velocity to a Redshift, approximate
+    * Converts the apparent radial velocity to a Redshift
     */
   def toRedshift: Redshift = Redshift((cz / RadialVelocity.C).value)
 }
@@ -25,7 +23,7 @@ final case class ApparentRadialVelocity(cz: RadialVelocity.RVQuantity) {
 object ApparentRadialVelocity {
 
   /**
-    * `No ApparentRadialVelocity`
+    * `Zero ApparentRadialVelocity`
     * @group Constructors
     */
   val Zero: ApparentRadialVelocity = new ApparentRadialVelocity(0.withUnit[RadialVelocity.RVUnit])

--- a/modules/model/shared/src/main/scala/gem/RadialVelocity.scala
+++ b/modules/model/shared/src/main/scala/gem/RadialVelocity.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import spire.std.bigDecimal._
+
+/**
+  * Representation of a radial velocity in kilomoters per second
+  * Valid range is ]-C, C[ where C is the speed of light
+  * This is often represented as RV
+  */
+final case class RadialVelocity private (rv: RadialVelocity.RVQuantity) {
+
+  /**
+    * Converts the radial velocity to a Redshift, approximate
+    * a return value of None should be understood as an infinity Redshift
+    */
+  def toRedshift: Option[Redshift] =
+    // Though we forbid constructing an RV with value C there is at least one instance with that value
+    if (rv.value.abs < RadialVelocity.CValue) {
+      val i = (rv / RadialVelocity.C).value
+      val t = (1 + i) / (1 - i)
+      Some(Redshift(BigDecimal.decimal(scala.math.sqrt(t.toDouble) - 1).round(rv.value.mc)))
+    } else None
+}
+
+object RadialVelocity {
+  type RVUnit     = (Kilo %* Meter) %/ Second
+  type RVQuantity = Quantity[BigDecimal, RVUnit]
+
+  val CValue: BigDecimal = BigDecimal.decimal(299792.458) // Use the default math context
+
+  val C: RVQuantity =
+    CValue.withUnit[RVUnit] // Speed of light in km/s
+
+  val CRadialVelocity: RadialVelocity = new RadialVelocity(C)
+
+  def apply(rv: RadialVelocity.RVQuantity): Option[RadialVelocity] =
+    if (rv.value.abs < CValue) Some(new RadialVelocity(rv)) else None
+
+  def unsafeFromRVQuantity(rv: RadialVelocity.RVQuantity): RadialVelocity =
+    apply(rv).getOrElse(sys.error(s"Value of rv $rv not allowed"))
+
+  /**
+    * `No RadialVelocity`
+    * @group Constructors
+    */
+  val Zero: RadialVelocity = new RadialVelocity(0.withUnit[RVUnit])
+
+  /** @group Typeclass Instances */
+  implicit val order: Order[RadialVelocity] =
+    Order.by(_.rv.value)
+
+}

--- a/modules/model/shared/src/main/scala/gem/RadialVelocity.scala
+++ b/modules/model/shared/src/main/scala/gem/RadialVelocity.scala
@@ -10,9 +10,9 @@ import coulomb.siprefix._
 import spire.std.bigDecimal._
 
 /**
-  * Representation of a radial velocity in kilomoters per second
+  * Representation of a radial velocity in kilometers per second
   * Valid range is ]-C, C[ where C is the speed of light
-  * This is often represented as RV
+  * Radiav Velocity is often represented as RV
   */
 final case class RadialVelocity private (rv: RadialVelocity.RVQuantity) {
 
@@ -40,14 +40,22 @@ object RadialVelocity {
 
   val CRadialVelocity: RadialVelocity = new RadialVelocity(C)
 
+  /**
+    * Construct a RadialVelocity if the value is in the allowed range
+    * @group Constructors
+    */
   def apply(rv: RadialVelocity.RVQuantity): Option[RadialVelocity] =
     if (rv.value.abs < CValue) Some(new RadialVelocity(rv)) else None
 
+  /**
+    * Attempts to construct a RadialVelocity, it will fail if the value is outside the allowed range
+    * @group Constructors
+    */
   def unsafeFromRVQuantity(rv: RadialVelocity.RVQuantity): RadialVelocity =
     apply(rv).getOrElse(sys.error(s"Value of rv $rv not allowed"))
 
   /**
-    * `No RadialVelocity`
+    * `Zero RadialVelocity`
     * @group Constructors
     */
   val Zero: RadialVelocity = new RadialVelocity(0.withUnit[RVUnit])

--- a/modules/model/shared/src/main/scala/gem/RadialVelocity.scala
+++ b/modules/model/shared/src/main/scala/gem/RadialVelocity.scala
@@ -8,11 +8,12 @@ import coulomb._
 import coulomb.si._
 import coulomb.siprefix._
 import spire.std.bigDecimal._
+import java.math.MathContext
 
 /**
   * Representation of a radial velocity in kilometers per second
-  * Valid range is ]-C, C[ where C is the speed of light
-  * Radiav Velocity is often represented as RV
+  * Valid range is (-C, C) where C is the speed of light
+  * Radial Velocity is often represented as RV
   */
 final case class RadialVelocity private (rv: RadialVelocity.RVQuantity) {
 
@@ -30,15 +31,16 @@ final case class RadialVelocity private (rv: RadialVelocity.RVQuantity) {
 }
 
 object RadialVelocity {
+  type CUnit      = Meter %/ Second
   type RVUnit     = (Kilo %* Meter) %/ Second
   type RVQuantity = Quantity[BigDecimal, RVUnit]
 
-  val CValue: BigDecimal = BigDecimal.decimal(299792.458) // Use the default math context
+  // Reference: https://www.nist.gov/si-redefinition/meet-constants
+  // Exact value of the speed of light in m/s
+  private val CValue: BigDecimal = BigDecimal.decimal(299792458, MathContext.DECIMAL64)
 
   val C: RVQuantity =
-    CValue.withUnit[RVUnit] // Speed of light in km/s
-
-  val CRadialVelocity: RadialVelocity = new RadialVelocity(C)
+    CValue.withUnit[CUnit].toUnit[RVUnit] // Speed of light in km/s
 
   /**
     * Construct a RadialVelocity if the value is in the allowed range

--- a/modules/model/shared/src/main/scala/gem/Redshift.scala
+++ b/modules/model/shared/src/main/scala/gem/Redshift.scala
@@ -4,37 +4,41 @@
 package gem
 
 import cats._
+import cats.implicits._
 import coulomb._
-import coulomb.si._
-import coulomb.siprefix._
-import spire.std.bigDecimal._
 
-case class Redshift(z: BigDecimal)
+/**
+  * Represents a redshift of an object if it move away or towards the observing point
+  * Redshift can be higher than 1 or negative
+  * Redshift can be converted to RadialVelocity which takes into account relativistic effects and cannot be more than C
+  * For nearer objects we can convert to ApparentRadialVelocity which doesn't consider relativistic effects
+  * Offten Redshift is referred as z
+  */
+final case class Redshift(z: BigDecimal) {
+
+  /**
+    * Converts to RadialVelocity, approximate
+    */
+  def toRadialVelocity: Option[RadialVelocity] = {
+    val rv = RadialVelocity.CValue * (((z + 1) * (z + 1) - 1) / ((z + 1) * (z + 1) + 1))
+    RadialVelocity(rv.round(z.mc).withUnit[RadialVelocity.RVUnit])
+  }
+
+  // // We need a Functor[Quantity]
+  // def toApparentRadialVelocity: RadialVelocity =
+  //   RadialVelocity((RadialVelocity.CValue * z).withUnit[RadialVelocity.RVUnit])
+}
 
 object Redshift {
-  type RadialVelocity         = (Kilo %* Meter) %/ Second
-  type RadialVelocityQuantity = Quantity[BigDecimal, RadialVelocity]
-
-  val C: RadialVelocityQuantity =
-    299792.458.withUnit[RadialVelocity] // Speed of light in km/s
-
-  /** @group Typeclass Instances */
-  implicit val eqRedshift: Eq[Redshift] = Eq.by(_.z)
 
   /**
     * The `No redshift`
     * @group Constructors
     */
-  val Zero: Redshift = Redshift(0)
+  val Zero: Redshift = new Redshift(0)
 
   /** @group Typeclass Instances */
   implicit val order: Order[Redshift] =
     Order.by(_.z)
 
-  def fromVelocity(v: RadialVelocityQuantity): Option[Redshift] =
-    if (v < C) {
-      val i = (v / C).value
-      val t = (1 + i) / (1 - i)
-      Some(Redshift(scala.math.sqrt(t.toDouble) - 1))
-    } else None
 }

--- a/modules/model/shared/src/main/scala/gem/Redshift.scala
+++ b/modules/model/shared/src/main/scala/gem/Redshift.scala
@@ -9,8 +9,8 @@ import coulomb._
 
 /**
   * Represents a redshift of an object as it moves away (positive) or towards (negative) the observing point
-  * 
-  * Redshift can be (perhaps suprpsinginly) higher than 1.
+  *
+  * Redshift can be (perhaps surprisingly) higher than 1.
   *
   * For far objects Redshift can be converted to RadialVelocity which takes into account relativistic effects and cannot be more than C
   * For nearer objects we can convert to ApparentRadialVelocity which doesn't consider relativistic effects
@@ -23,12 +23,12 @@ final case class Redshift(z: BigDecimal) {
     * Converts to RadialVelocity, approximate
     */
   def toRadialVelocity: Option[RadialVelocity] = {
-    val rv = RadialVelocity.CValue * (((z + 1) * (z + 1) - 1) / ((z + 1) * (z + 1) + 1))
+    val rv = RadialVelocity.C.value * (((z + 1) * (z + 1) - 1) / ((z + 1) * (z + 1) + 1))
     RadialVelocity(rv.round(z.mc).withUnit[RadialVelocity.RVUnit])
   }
 
   def toApparentRadialVelocity: ApparentRadialVelocity =
-    ApparentRadialVelocity((RadialVelocity.CValue * z).withUnit[RadialVelocity.RVUnit])
+    ApparentRadialVelocity((RadialVelocity.C.value * z).withUnit[RadialVelocity.RVUnit])
 }
 
 object Redshift {

--- a/modules/model/shared/src/main/scala/gem/Redshift.scala
+++ b/modules/model/shared/src/main/scala/gem/Redshift.scala
@@ -24,9 +24,9 @@ final case class Redshift(z: BigDecimal) {
     RadialVelocity(rv.round(z.mc).withUnit[RadialVelocity.RVUnit])
   }
 
-  // // We need a Functor[Quantity]
-  // def toApparentRadialVelocity: RadialVelocity =
-  //   RadialVelocity((RadialVelocity.CValue * z).withUnit[RadialVelocity.RVUnit])
+  // We need a Functor[Quantity]
+  def toApparentRadialVelocity: ApparentRadialVelocity =
+    ApparentRadialVelocity((RadialVelocity.CValue * z).withUnit[RadialVelocity.RVUnit])
 }
 
 object Redshift {

--- a/modules/model/shared/src/main/scala/gem/Redshift.scala
+++ b/modules/model/shared/src/main/scala/gem/Redshift.scala
@@ -8,11 +8,14 @@ import cats.implicits._
 import coulomb._
 
 /**
-  * Represents a redshift of an object if it move away or towards the observing point
-  * Redshift can be higher than 1 or negative
-  * Redshift can be converted to RadialVelocity which takes into account relativistic effects and cannot be more than C
+  * Represents a redshift of an object as it moves away (positive) or towards (negative) the observing point
+  * 
+  * Redshift can be (perhaps suprpsinginly) higher than 1.
+  *
+  * For far objects Redshift can be converted to RadialVelocity which takes into account relativistic effects and cannot be more than C
   * For nearer objects we can convert to ApparentRadialVelocity which doesn't consider relativistic effects
-  * Offten Redshift is referred as z
+  *
+  * Often Redshift is referred as z
   */
 final case class Redshift(z: BigDecimal) {
 
@@ -24,7 +27,6 @@ final case class Redshift(z: BigDecimal) {
     RadialVelocity(rv.round(z.mc).withUnit[RadialVelocity.RVUnit])
   }
 
-  // We need a Functor[Quantity]
   def toApparentRadialVelocity: ApparentRadialVelocity =
     ApparentRadialVelocity((RadialVelocity.CValue * z).withUnit[RadialVelocity.RVUnit])
 }

--- a/modules/model/shared/src/main/scala/gem/Redshift.scala
+++ b/modules/model/shared/src/main/scala/gem/Redshift.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+
+import cats._
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import spire.std.bigDecimal._
+
+case class Redshift(z: BigDecimal)
+
+object Redshift {
+  type RadialVelocity         = (Kilo %* Meter) %/ Second
+  type RadialVelocityQuantity = Quantity[BigDecimal, RadialVelocity]
+
+  val C: RadialVelocityQuantity =
+    299792.458.withUnit[RadialVelocity] // Speed of light in km/s
+
+  /** @group Typeclass Instances */
+  implicit val eqRedshift: Eq[Redshift] = Eq.by(_.z)
+
+  /**
+    * The `No redshift`
+    * @group Constructors
+    */
+  val Zero: Redshift = Redshift(0)
+
+  /** @group Typeclass Instances */
+  implicit val order: Order[Redshift] =
+    Order.by(_.z)
+
+  def fromVelocity(v: RadialVelocityQuantity): Option[Redshift] =
+    if (v < C) {
+      val i = (v / C).value
+      val t = (1 + i) / (1 - i)
+      Some(Redshift(scala.math.sqrt(t.toDouble) - 1))
+    } else None
+}

--- a/modules/model/shared/src/main/scala/gem/SpatialProfile.scala
+++ b/modules/model/shared/src/main/scala/gem/SpatialProfile.scala
@@ -14,6 +14,7 @@ object SpatialProfile {
   case object UniformSource extends SpatialProfile
   final case class GaussianSource(fwhm: Angle) extends SpatialProfile
 
+  /** @group Typeclass Instances */
   implicit val eqSpatialProfile: Eq[SpatialProfile] = Eq.instance {
     case (PointSource, PointSource)             => true
     case (UniformSource, UniformSource)         => true

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbApparentRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbApparentRadialVelocity.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import coulomb._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+
+trait ArbApparentRadialVelocity {
+
+  implicit val arbApparentRadialVelocity: Arbitrary[ApparentRadialVelocity] =
+    Arbitrary {
+      for {
+        cz <- arbitrary[BigDecimal]
+      } yield ApparentRadialVelocity(cz.withUnit[RadialVelocity.RVUnit])
+    }
+
+  implicit val cogRedshift: Cogen[ApparentRadialVelocity] =
+    Cogen[BigDecimal].contramap(_.cz.value)
+}
+
+object ArbApparentRadialVelocity extends ArbApparentRadialVelocity

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import coulomb._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Cogen
+
+trait ArbRadialVelocity {
+
+  implicit val arbRedshift: Arbitrary[RadialVelocity] =
+    Arbitrary {
+      for {
+        rv <-
+          Gen.chooseNum(-1 * RadialVelocity.CValue.toDouble + 1, RadialVelocity.CValue.toDouble - 1)
+      } yield RadialVelocity.unsafeFromRVQuantity(rv.withUnit[RadialVelocity.RVUnit])
+    }
+
+  implicit val cogRedshift: Cogen[RadialVelocity] =
+    Cogen[BigDecimal].contramap(_.rv.value)
+}
+
+object ArbRadialVelocity extends ArbRadialVelocity

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
@@ -11,7 +11,7 @@ import org.scalacheck.Cogen
 
 trait ArbRadialVelocity {
 
-  implicit val arbRedshift: Arbitrary[RadialVelocity] =
+  implicit val arbRadialVelocity: Arbitrary[RadialVelocity] =
     Arbitrary {
       for {
         rv <-
@@ -19,7 +19,7 @@ trait ArbRadialVelocity {
       } yield RadialVelocity.unsafeFromRVQuantity(rv.withUnit[RadialVelocity.RVUnit])
     }
 
-  implicit val cogRedshift: Cogen[RadialVelocity] =
+  implicit val cogRadialVelocity: Cogen[RadialVelocity] =
     Cogen[BigDecimal].contramap(_.rv.value)
 }
 

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
@@ -14,8 +14,9 @@ trait ArbRadialVelocity {
   implicit val arbRadialVelocity: Arbitrary[RadialVelocity] =
     Arbitrary {
       for {
-        rv <-
-          Gen.chooseNum(-1 * RadialVelocity.CValue.toDouble + 1, RadialVelocity.CValue.toDouble - 1)
+        rv <- Gen.chooseNum(-1 * RadialVelocity.C.value.toDouble + 1,
+                            RadialVelocity.C.value.toDouble - 1
+              )
       } yield RadialVelocity.unsafeFromRVQuantity(rv.withUnit[RadialVelocity.RVUnit])
     }
 

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbRadialVelocity.scala
@@ -6,8 +6,8 @@ package arb
 
 import coulomb._
 import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
 import org.scalacheck.Cogen
+import org.scalacheck.Gen
 
 trait ArbRadialVelocity {
 

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbRedshift.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbRedshift.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gem
+package arb
+
+import gem.Redshift
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Arbitrary._
+
+trait ArbRedshift {
+
+  implicit val arbRedshift: Arbitrary[Redshift] =
+    Arbitrary {
+      for {
+        rs <- arbitrary[BigDecimal]
+      } yield Redshift(rs)
+    }
+
+  implicit val cogRedshift: Cogen[Redshift] =
+    Cogen[BigDecimal].contramap(_.z)
+}
+
+object ArbRedshift extends ArbRedshift

--- a/modules/testkit/shared/src/main/scala/gem/arb/ArbRedshift.scala
+++ b/modules/testkit/shared/src/main/scala/gem/arb/ArbRedshift.scala
@@ -7,14 +7,14 @@ package arb
 import gem.Redshift
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
 
 trait ArbRedshift {
 
   implicit val arbRedshift: Arbitrary[Redshift] =
     Arbitrary {
       for {
-        rs <- arbitrary[BigDecimal]
+        rs <- Gen.chooseNum(-10.0, 10.0)
       } yield Redshift(rs)
     }
 


### PR DESCRIPTION
This PR adds three entities that are related between them, describing the velocity a target is going away/towards us in different ways.

This is loosely based on the ocs implementation though I've replaced `squants` by `coulomb`

This is also a RFC about using `coulomb`, if we use it is likely a long term commitment. In this PR we cues coulomb to say that `RadialVelocity` is defined in km/s and unlike `squants` we can use `BigDecimal` (or other numeric types) for the value.
Using coulomb is of course a long term commitment but it seems they are open to get help.

The PR uses a locally built version of coulomb that supports scala.js and I verified that all tests run in js