### PR TITLE
Convenience method to convert Site to Place.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ out/
 
 # Vim
 *.swp
+
+# Scalafmt
+.scalafmt.conf

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val catsVersion                 = "2.1.1"
 lazy val catsTestkitScalaTestVersion = "1.0.1"
 lazy val fs2Version                  = "2.4.2"
 lazy val geminiLocalesVersion        = "0.5.0"
-lazy val gspMathVersion              = "0.2.4"
+lazy val gspMathVersion              = "0.2.5"
 lazy val kindProjectorVersion        = "0.11.0"
 lazy val monocleVersion              = "2.0.5"
 lazy val paradiseVersion             = "2.1.1"
@@ -18,11 +18,15 @@ lazy val silencerVersion             = "1.6.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-inThisBuild(Seq(
-  homepage := Some(url("https://github.com/gemini-hlsw/gsp-core")),
-  addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorVersion cross CrossVersion.full),
-  scalacOptions += "-Ymacro-annotations",
-) ++ gspPublishSettings)
+inThisBuild(
+  Seq(
+    homepage := Some(url("https://github.com/gemini-hlsw/gsp-core")),
+    addCompilerPlugin(
+      ("org.typelevel" % "kind-projector" % kindProjectorVersion).cross(CrossVersion.full)
+    ),
+    scalacOptions += "-Ymacro-annotations"
+  ) ++ gspPublishSettings
+)
 
 // doesn't work to do this `inThisBuild`
 lazy val commonSettings = Seq(
@@ -34,8 +38,13 @@ lazy val commonSettings = Seq(
 // don't publish an artifact for the [empty] root project
 skip in publish := true
 
-addCommandAlias("genEnums", "; gen/runMain gem.sql.Main modules/model/shared/src/main/scala/gem/enum; headerCreate")
-addCommandAlias("rebuildEnums", "; schema/flywayClean; schema/flywayMigrate; genEnums; modelJVM/compile")
+addCommandAlias(
+  "genEnums",
+  "; gen/runMain gem.sql.Main modules/model/shared/src/main/scala/gem/enum; headerCreate"
+)
+addCommandAlias("rebuildEnums",
+                "; schema/flywayClean; schema/flywayMigrate; genEnums; modelJVM/compile"
+)
 
 lazy val schema = project
   .in(file("modules/schema"))
@@ -44,7 +53,7 @@ lazy val schema = project
   .settings(
     name := "gsp-core-schema",
     skip in publish := true,
-    flywayUrl  := "jdbc:postgresql:gem",
+    flywayUrl := "jdbc:postgresql:gem",
     flywayUser := "postgres",
     flywayLocations := Seq(
       s"filesystem:${baseDirectory.value}/src/main/resources/db/migration"
@@ -164,7 +173,8 @@ lazy val ephemeris = project
     // to run these:
     //    sbt:gsp-core-ephemeris> set Test/testOptions := Nil
     //    sbt:gsp-core-ephemeris> test
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork"),
+    testOptions in Test += Tests
+      .Argument(TestFrameworks.ScalaTest, "-l", "gem.test.Tags.RequiresNetwork"),
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-async-http-client" % http4sVersion,
       "org.typelevel" %% "mouse"                    % mouseVersion

--- a/modules/model/shared/src/main/scala/gem/enum/Site.scala
+++ b/modules/model/shared/src/main/scala/gem/enum/Site.scala
@@ -8,27 +8,58 @@ import cats.instances.string._
 import cats.syntax.eq._
 import gem.util.Enumerated
 import gsp.math.Angle
+import gsp.math.Lat
+import gsp.math.Place
 import java.time.ZoneId
 
 /**
- * Enumerated type for Gemini observing sites.
- * @group Enumerations (Generated)
- */
+  * Enumerated type for Gemini observing sites.
+  * @group Enumerations (Generated)
+  */
 sealed abstract class Site(
-  val tag: String,
+  val tag:       String,
   val shortName: String,
-  val longName: String,
-  val mountain: String,
-  val latitude: Angle,
+  val longName:  String,
+  val mountain:  String,
+  val latitude:  Angle,
   val longitude: Angle,
-  val altitude: Int,
-  val timezone: ZoneId
-) extends Product with Serializable
+  val altitude:  Int,
+  val timezone:  ZoneId
+) extends Product
+    with Serializable {
+  def toPlace: Place =
+    Place(
+      Lat.fromAngleWithCarry(latitude)._1,
+      longitude,
+      altitude.toDouble
+    )
+}
 
 object Site {
 
-  /** @group Constructors */ case object GN extends Site("GN", "GN", "Gemini North", "Mauna Kea", Angle.fromDoubleDegrees(19.8238068), Angle.fromDoubleDegrees(-155.4690550), 4213, ZoneId.of("Pacific/Honolulu"))
-  /** @group Constructors */ case object GS extends Site("GS", "GS", "Gemini South", "Cerro Pachon", Angle.fromDoubleDegrees(-30.2407494), Angle.fromDoubleDegrees(-70.7366867), 2722, ZoneId.of("America/Santiago"))
+  /** @group Constructors */
+  case object GN
+      extends Site("GN",
+                   "GN",
+                   "Gemini North",
+                   "Mauna Kea",
+                   Angle.fromDoubleDegrees(19.8238068),
+                   Angle.fromDoubleDegrees(-155.4690550),
+                   4213,
+                   ZoneId.of("Pacific/Honolulu")
+      )
+
+  /** @group Constructors */
+  case object GS
+      extends Site("GS",
+                   "GS",
+                   "Gemini South",
+                   "Cerro Pachon",
+                   Angle.fromDoubleDegrees(-30.2407494),
+                   Angle.fromDoubleDegrees(-70.7366867),
+                   2722,
+                   ZoneId.of("America/Santiago")
+      )
 
   /** All members of Site, in canonical order. */
   val all: List[Site] =
@@ -46,7 +77,7 @@ object Site {
   implicit val SiteEnumerated: Enumerated[Site] =
     new Enumerated[Site] {
       def all = Site.all
-      def tag(a: Site) = a.tag
+      def tag(a:                    Site)         = a.tag
       override def unsafeFromTag(s: String): Site =
         Site.unsafeFromTag(s)
     }


### PR DESCRIPTION
Since SkyCalc takes a Place as input, the method `Site.toPlace` allows convenient conversion.

Also, some formatting.